### PR TITLE
Improve error handling by removing panics, unwraps, and expects

### DIFF
--- a/src/bin/abacus.rs
+++ b/src/bin/abacus.rs
@@ -65,7 +65,12 @@ fn main() {
                 if table_number > 0 {
                     println!(",");
                 }
-                println!("{}", table.output(table_format.clone()));
+                println!(
+                    "{}",
+                    table
+                        .output(table_format.clone())
+                        .expect("error while writing output")
+                );
             }
             println!("\n]\n");
         }

--- a/src/bin/tab2.rs
+++ b/src/bin/tab2.rs
@@ -50,7 +50,12 @@ fn main() {
         Ok((context, rq)) => match tabulate::tabulate(&context, rq) {
             Ok(tables) => {
                 for table in tables {
-                    println!("{}", table.output(table_format.clone()));
+                    println!(
+                        "{}",
+                        table
+                            .output(table_format.clone())
+                            .expect("error while writing output")
+                    );
                 }
             }
             Err(e) => {

--- a/src/conventions.rs
+++ b/src/conventions.rs
@@ -345,23 +345,20 @@ impl MetadataEntities {
     }
 
     pub fn add_dataset_variable(&mut self, dataset: IpumsDataset, variable: IpumsVariable) {
-        let dataset_name = &dataset.name.clone();
-        let variable_name = &variable.name.clone();
-
-        let dataset_id: IpumsDatasetId = if self.datasets_by_name.contains_key(dataset_name) {
-            *self.datasets_by_name.get(dataset_name).unwrap()
-        } else {
-            self.create_dataset(dataset)
+        let dataset_id = match self.datasets_by_name.get(&dataset.name) {
+            None => self.create_dataset(dataset),
+            Some(dataset_id) => *dataset_id,
         };
 
-        let variable_id: IpumsVariableId = if self.variables_by_name.contains_key(variable_name) {
-            *self.variables_by_name.get(variable_name).unwrap()
-        } else {
-            self.create_variable(variable)
+        let variable_id = match self.variables_by_name.get(&variable.name) {
+            None => self.create_variable(variable),
+            Some(variable_id) => *variable_id,
         };
+
         self.connect(dataset_id, variable_id);
     }
 }
+
 /// This is the mutable state  created and passed around holding the loaded metadata if any
 /// and the rest of the information needed to add paths to the data tables used in queries
 /// and data file paths, and where the metadata can be found.

--- a/src/conventions.rs
+++ b/src/conventions.rs
@@ -126,21 +126,21 @@ impl MicroDataCollection {
         &mut self,
         datasets: &[&str],
         data_root: &Path,
-    ) {
+    ) -> Result<(), MdError> {
         let mut md = MetadataEntities::new();
         for (index_ds, ds) in datasets.iter().enumerate() {
             let ipums_dataset = IpumsDataset::from((ds.to_string(), index_ds));
             let layouts_path = data_root.to_path_buf().join("layouts");
             let layout = layout::DatasetLayout::try_from_layout_file(
                 &layouts_path.join(format!("{}.layout.txt", ds)),
-            )
-            .unwrap();
+            )?;
             for (index_v, var) in layout.all_variables().iter().enumerate() {
                 let ipums_var = IpumsVariable::from((var, index_v));
                 md.add_dataset_variable(ipums_dataset.clone(), ipums_var);
             }
         }
         self.metadata = Some(md);
+        Ok(())
     }
 
     /// Uses default product_root to find metadata database and load all metadata for given datasets.
@@ -460,8 +460,7 @@ impl Context {
         if !self.enable_full_metadata {
             if let Some(ref data_root) = self.data_root {
                 self.settings
-                    .load_metadata_for_selected_datasets_from_layouts(datasets, &data_root);
-                Ok(())
+                    .load_metadata_for_selected_datasets_from_layouts(datasets, &data_root)
             } else {
                 Err(MdError::Msg("Cannot load any metadata without a data_root or full metadata available ad the product_root.".to_string()))
             }

--- a/src/conventions.rs
+++ b/src/conventions.rs
@@ -510,7 +510,7 @@ impl Context {
             name: name.to_string(),
             product_root: Some(product_root),
             data_root: Some(data_root),
-            settings: defaults::defaults_for(name),
+            settings: defaults::defaults_for(name).unwrap(),
             allow_full_metadata,
             enable_full_metadata: false,
         }
@@ -593,7 +593,8 @@ mod test {
 
     #[test]
     fn test_micro_data_collection_default_table_name() {
-        let collection = defaults::defaults_for("usa");
+        let collection =
+            defaults::defaults_for("usa").expect("should be able to get defaults for USA");
         let table_name = collection
             .default_table_name("us2021a", "P")
             .expect("should get a table name back because P is a valid record type");
@@ -602,7 +603,8 @@ mod test {
 
     #[test]
     fn test_micro_data_collection_default_table_name_unknown_rectype_error() {
-        let collection = defaults::defaults_for("usa");
+        let collection =
+            defaults::defaults_for("usa").expect("should be able to get defaults for USA");
         let result = collection.default_table_name("us2021a", "Z");
         assert!(result.is_err(), "expected an error but got {result:?}");
     }

--- a/src/conventions.rs
+++ b/src/conventions.rs
@@ -308,20 +308,28 @@ impl DatasetsForVariable {
 
 impl MetadataEntities {
     #[allow(dead_code)]
-    fn connect_names(&mut self, dataset_name: &str, variable_name: &str) {
+    fn connect_names(&mut self, dataset_name: &str, variable_name: &str) -> Result<(), MdError> {
         let dataset_id = self.datasets_by_name.get(dataset_name);
         let variable_id = self.variables_by_name.get(variable_name);
         if variable_id.is_none() {
-            panic!("Internal method connect() should never be called with non-existent metadata names.");
+            let msg = format!(
+                "method connect_names() called with variable name {variable_name}, which is not in metadata"
+            );
+            return Err(MdError::NotInMetadata(msg));
         }
 
         if dataset_id.is_none() {
-            panic!("Internal method connect() should never be called with non-existent metadata names.");
+            let msg = format!(
+                "method connect_names() called with dataset name {dataset_name}, which is not in metadata"
+            );
+            return Err(MdError::NotInMetadata(msg));
         }
 
         if let (Some(did), Some(vid)) = (dataset_id, variable_id) {
             self.connect(*did, *vid);
         };
+
+        Ok(())
     }
 
     fn connect(&mut self, dataset_id: IpumsDatasetId, variable_id: IpumsVariableId) {

--- a/src/conventions.rs
+++ b/src/conventions.rs
@@ -458,7 +458,7 @@ impl Context {
                 panic!("Cannot load any metadata without a data_root or full metadata available ad the product_root.");
             }
         } else {
-            panic!("Loading metadata from database not implemented.");
+            todo!("Loading metadata from database not implemented.");
         }
     }
 

--- a/src/conventions.rs
+++ b/src/conventions.rs
@@ -578,4 +578,18 @@ mod test {
             );
         }
     }
+
+    #[test]
+    fn test_micro_data_collection_default_table_name() {
+        let collection = defaults::defaults_for("usa");
+        let table_name = collection.default_table_name("us2021a", "P");
+        assert_eq!(table_name, "us2021a_usa_person");
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_micro_data_collection_default_table_name_unknown_rectype_error() {
+        let collection = defaults::defaults_for("usa");
+        collection.default_table_name("us2021a", "Z");
+    }
 }

--- a/src/conventions.rs
+++ b/src/conventions.rs
@@ -127,9 +127,10 @@ impl MicroDataCollection {
         for (index_ds, ds) in datasets.iter().enumerate() {
             let ipums_dataset = IpumsDataset::from((ds.to_string(), index_ds));
             let layouts_path = data_root.to_path_buf().join("layouts");
-            let layout = layout::DatasetLayout::from_layout_file(
+            let layout = layout::DatasetLayout::try_from_layout_file(
                 &layouts_path.join(format!("{}.layout.txt", ds)),
-            );
+            )
+            .unwrap();
             for (index_v, var) in layout.all_variables().iter().enumerate() {
                 let ipums_var = IpumsVariable::from((var, index_v));
                 md.add_dataset_variable(ipums_dataset.clone(), ipums_var);

--- a/src/conventions.rs
+++ b/src/conventions.rs
@@ -374,7 +374,7 @@ impl Context {
             if let Some(var) = md.cloned_variable_from_name(name) {
                 Ok(var)
             } else {
-                Err(MdError::Msg(format!(
+                Err(MdError::NotInMetadata(format!(
                     "Variable '{}' not in loaded metadata.",
                     name
                 )))

--- a/src/conventions.rs
+++ b/src/conventions.rs
@@ -459,13 +459,14 @@ impl Context {
     }
 
     /// When called, the context should be already set to read from layouts or full metadata
-    pub fn load_metadata_for_datasets(&mut self, datasets: &[&str]) {
+    pub fn load_metadata_for_datasets(&mut self, datasets: &[&str]) -> Result<(), MdError> {
         if !self.enable_full_metadata {
             if let Some(ref data_root) = self.data_root {
                 self.settings
                     .load_metadata_for_selected_datasets_from_layouts(datasets, &data_root);
+                Ok(())
             } else {
-                panic!("Cannot load any metadata without a data_root or full metadata available ad the product_root.");
+                Err(MdError::Msg("Cannot load any metadata without a data_root or full metadata available ad the product_root.".to_string()))
             }
         } else {
             todo!("Loading metadata from database not implemented.");

--- a/src/conventions.rs
+++ b/src/conventions.rs
@@ -31,7 +31,7 @@ use crate::defaults;
 use crate::ipums_data_model::*;
 use crate::ipums_metadata_model::*;
 use crate::layout;
-use crate::mderror::MdError;
+use crate::mderror::{metadata_error, MdError};
 use crate::request::InputType;
 
 use std::collections::HashMap;
@@ -317,17 +317,17 @@ impl MetadataEntities {
         let dataset_id = self.datasets_by_name.get(dataset_name);
         let variable_id = self.variables_by_name.get(variable_name);
         if variable_id.is_none() {
-            let msg = format!(
+            let err = metadata_error!(
                 "method connect_names() called with variable name {variable_name}, which is not in metadata"
             );
-            return Err(MdError::NotInMetadata(msg));
+            return Err(err);
         }
 
         if dataset_id.is_none() {
-            let msg = format!(
+            let err = metadata_error!(
                 "method connect_names() called with dataset name {dataset_name}, which is not in metadata"
             );
-            return Err(MdError::NotInMetadata(msg));
+            return Err(err);
         }
 
         if let (Some(did), Some(vid)) = (dataset_id, variable_id) {
@@ -384,14 +384,11 @@ impl Context {
             if let Some(var) = md.cloned_variable_from_name(name) {
                 Ok(var)
             } else {
-                Err(MdError::NotInMetadata(format!(
-                    "Variable '{}' not in loaded metadata.",
-                    name
-                )))
+                Err(metadata_error!("Variable '{name}' not in loaded metadata.",))
             }
         } else {
-            Err(MdError::Msg(
-                "No metadata loaded. Can't get variable.".to_string(),
+            Err(metadata_error!(
+                "No metadata loaded. Can't get variable '{name}'."
             ))
         }
     }
@@ -458,7 +455,7 @@ impl Context {
                 self.settings
                     .load_metadata_for_selected_datasets_from_layouts(datasets, &data_root)
             } else {
-                Err(MdError::Msg("Cannot load any metadata without a data_root or full metadata available ad the product_root.".to_string()))
+                Err(metadata_error!("Cannot load any metadata without a data_root or full metadata available ad the product_root."))
             }
         } else {
             todo!("Loading metadata from database not implemented.");

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -6,6 +6,7 @@
 
 use crate::conventions::*;
 use crate::ipums_data_model::*;
+use crate::mderror::MdError;
 use std::collections::HashMap;
 
 fn household() -> RecordType {
@@ -61,7 +62,7 @@ fn default_settings_named(name: &str) -> MicroDataCollection {
 /// Get them like
 /// ```
 /// use cimdea::defaults::defaults_for;
-/// let current_settings = defaults_for("usa");
+/// let current_settings = defaults_for("usa").unwrap();
 /// ```
 ///
 ///
@@ -70,11 +71,34 @@ fn default_settings_named(name: &str) -> MicroDataCollection {
 /// Right now we only set defaults programmatically but in future this should set some additional
 /// properties particular to products or stuff loaded in from
 // an external configuration.
-pub fn defaults_for(product: &str) -> MicroDataCollection {
+pub fn defaults_for(product: &str) -> Result<MicroDataCollection, MdError> {
     match product.to_lowercase().as_ref() {
-        "usa" => default_settings_named("USA"),
-        "cps" => default_settings_named("cps"),
-        "ipumsi" => default_settings_named("ipumsi"),
-        _ => panic!("Product not supported"),
+        "usa" => Ok(default_settings_named("USA")),
+        "cps" => Ok(default_settings_named("cps")),
+        "ipumsi" => Ok(default_settings_named("ipumsi")),
+        _ => Err(MdError::Msg(format!("Product '{product}' not supported"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_defaults_for_usa() {
+        let result = defaults_for("usa");
+        assert!(
+            result.is_ok(),
+            "should be able to get defaults for product USA"
+        );
+    }
+
+    #[test]
+    fn test_defaults_for_unknown_product() {
+        let result = defaults_for("????");
+        assert!(
+            result.is_err(),
+            "there should not be any defaults for product '????'"
+        );
     }
 }

--- a/src/fixed_width.rs
+++ b/src/fixed_width.rs
@@ -5,6 +5,7 @@ use crate::layout;
 use crate::mderror::MdError;
 //use duckdb::arrow::datatypes::ToByteSlice;
 use ascii;
+use std::ffi::OsString;
 use std::path;
 
 const TRACE: bool = false;
@@ -28,7 +29,7 @@ impl Hflr {
     }
 
     pub fn try_new(filename: &str, selection_filter: Option<Vec<String>>) -> Result<Self, MdError> {
-        let l = layout::DatasetLayout::try_from_layout_file(path::Path::new(filename)).unwrap();
+        let l = layout::DatasetLayout::try_from_layout_file(path::Path::new(filename))?;
         // Decide how to handle problems with the selection_filter
         match selection_filter {
             None => Ok(Self {
@@ -74,7 +75,7 @@ fn dataset_from_path(fw_data_filename: &str) -> Result<String, MdError> {
 // return it if it exists. If nothing is in ../current/layouts/
 // then check the directory where the data file is, to account for
 // the -l DCP mode.
-pub fn layout_file_for(fw_file: &str) -> Result<String, MdError> {
+pub fn layout_file_for(fw_file: &str) -> Result<OsString, MdError> {
     let dataset = dataset_from_path(fw_file)?;
     let layout_filename = dataset + ".layout.txt";
 
@@ -100,9 +101,9 @@ pub fn layout_file_for(fw_file: &str) -> Result<String, MdError> {
                 &fw_data_file.display()
             )));
         }
-        Ok(local_layout_file.into_os_string().into_string().unwrap())
+        Ok(local_layout_file.into_os_string())
     } else {
-        Ok(layout_file.into_os_string().into_string().unwrap())
+        Ok(layout_file.into_os_string())
     }
 }
 
@@ -178,7 +179,6 @@ mod tests {
     }
 
     #[test]
-
     fn test_with_variable_selections() {
         use super::*;
         let selections = vec!["AGE".to_string(), "GQ".to_string(), "SERIAL".to_string()];

--- a/src/fixed_width.rs
+++ b/src/fixed_width.rs
@@ -165,9 +165,15 @@ mod tests {
         use super::*;
         let hflr = Hflr::try_new("test/data_root/layouts/us2015b.layout.txt", None)
             .expect("should be able to create Hflr from layout file");
-        let person_layout = hflr.layout.for_rectype("P");
+        let person_layout = hflr
+            .layout
+            .for_rectype("P")
+            .expect("should have layout for P record type");
         assert_eq!(628, person_layout.vars.len());
-        let hh_layout = hflr.layout.for_rectype("H");
+        let hh_layout = hflr
+            .layout
+            .for_rectype("H")
+            .expect("should have layout for H record type");
         assert_eq!(469, hh_layout.vars.len());
     }
 
@@ -181,9 +187,15 @@ mod tests {
             Some(selections),
         )
         .expect("should be able to create Hflr from layout file");
-        let person_layout = hflr.layout.for_rectype("P");
+        let person_layout = hflr
+            .layout
+            .for_rectype("P")
+            .expect("should have layout for P record type");
         assert_eq!(1, person_layout.vars().len());
-        let hh_layout = hflr.layout.for_rectype("H");
+        let hh_layout = hflr
+            .layout
+            .for_rectype("H")
+            .expect("should have layout for H record type");
 
         assert_eq!(2, hh_layout.vars().len());
     }

--- a/src/fixed_width.rs
+++ b/src/fixed_width.rs
@@ -27,7 +27,7 @@ impl Hflr {
     }
 
     pub fn new(filename: &str, selection_filter: Option<Vec<String>>) -> Self {
-        let l = layout::DatasetLayout::try_from_layout_file(filename.to_owned()).unwrap();
+        let l = layout::DatasetLayout::try_from_layout_file(path::Path::new(filename)).unwrap();
         // Decide how to handle problems with the selection_filter
         match selection_filter {
             None => Self {
@@ -143,9 +143,8 @@ pub fn make_zero_padded_numeric(code: &[u8]) -> Vec<u8> {
     new_code
 }
 
+#[cfg(test)]
 mod tests {
-
-
     #[test]
     fn test_make_zero_padded_numeric() {
         use super::*;
@@ -167,7 +166,7 @@ mod tests {
     #[test]
     fn test_hflr() {
         use super::*;
-        let hflr = Hflr::new("test_data/us2015b.layout.txt", None);
+        let hflr = Hflr::new("test/data_root/layouts/us2015b.layout.txt", None);
         let person_layout = hflr.layout.for_rectype("P");
         assert_eq!(628, person_layout.vars.len());
         let hh_layout = hflr.layout.for_rectype("H");
@@ -179,7 +178,10 @@ mod tests {
     fn test_with_variable_selections() {
         use super::*;
         let selections = vec!["AGE".to_string(), "GQ".to_string(), "SERIAL".to_string()];
-        let hflr = Hflr::new("test_data/us2015b.layout.txt", Some(selections));
+        let hflr = Hflr::new(
+            "test/data_root/layouts/us2015b.layout.txt",
+            Some(selections),
+        );
         let person_layout = hflr.layout.for_rectype("P");
         assert_eq!(1, person_layout.vars().len());
         let hh_layout = hflr.layout.for_rectype("H");

--- a/src/fixed_width.rs
+++ b/src/fixed_width.rs
@@ -27,7 +27,7 @@ impl Hflr {
     }
 
     pub fn new(filename: &str, selection_filter: Option<Vec<String>>) -> Self {
-        let l = layout::DatasetLayout::from_layout_file(filename.to_owned());
+        let l = layout::DatasetLayout::try_from_layout_file(filename.to_owned()).unwrap();
         // Decide how to handle problems with the selection_filter
         match selection_filter {
             None => Self {

--- a/src/input_schema_tabulation.rs
+++ b/src/input_schema_tabulation.rs
@@ -210,7 +210,7 @@ where
     D: Deserializer<'de>,
 {
     let maybe_gendet = Option::deserialize(deserializer)?;
-    Ok(maybe_gendet.unwrap_or(GeneralDetailedSelection::default()))
+    Ok(maybe_gendet.unwrap_or_default())
 }
 
 #[cfg(test)]

--- a/src/input_schema_tabulation.rs
+++ b/src/input_schema_tabulation.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::mderror::MdError;
+use crate::mderror::{parsing_error, MdError};
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AbacusRequest {
@@ -153,15 +153,14 @@ impl TryFrom<RequestCaseSelectionRaw> for RequestCaseSelection {
 
     fn try_from(value: RequestCaseSelectionRaw) -> Result<Self, Self::Error> {
         let Ok(low_code) = value.low_code.parse() else {
-            return Err(MdError::ParsingError(
-                "request_case_selections: cannot parse low_code as an unsigned integer".to_string(),
+            return Err(parsing_error!(
+                "request_case_selections: cannot parse low_code as an unsigned integer",
             ));
         };
 
         let Ok(high_code) = value.high_code.parse() else {
-            return Err(MdError::ParsingError(
+            return Err(parsing_error!(
                 "request_case_selections: cannot parse high_code as an unsigned integer"
-                    .to_string(),
             ));
         };
 

--- a/src/ipums_data_model.rs
+++ b/src/ipums_data_model.rs
@@ -106,4 +106,38 @@ mod test {
             "Should error out when adding a member with a parent type that doesn't exist."
         );
     }
+
+    #[test]
+    fn test_record_hierarchy_member_add_child_no_children_yet() {
+        let mut member = RecordHierarchyMember {
+            name: "H".to_string(),
+            children: None,
+            parent: None,
+        };
+
+        member.add_child("P");
+
+        let children = member
+            .children
+            .expect("should create a new set when adding the first child");
+        assert!(
+            children.contains("P"),
+            "P should be added to the new set of children"
+        );
+    }
+
+    #[test]
+    fn test_record_hierarchy_member_add_child_multiple() {
+        let children = HashSet::from(["I".to_string(), "X".to_string()]);
+        let mut member = RecordHierarchyMember {
+            name: "P".to_string(),
+            children: Some(children),
+            parent: Some("H".to_string()),
+        };
+
+        member.add_child("D");
+        let children = member.children.expect("should have a set of children");
+        let expected = HashSet::from(["I".to_string(), "X".to_string(), "D".to_string()]);
+        assert_eq!(expected, children);
+    }
 }

--- a/src/ipums_data_model.rs
+++ b/src/ipums_data_model.rs
@@ -42,12 +42,11 @@ pub struct RecordHierarchyMember {
 
 impl RecordHierarchyMember {
     pub fn add_child(&mut self, rectype: &str) {
-        if self.children.is_none() {
-            self.children = Some(HashSet::new());
-        }
-        self.children.as_mut().unwrap().insert(rectype.to_string());
+        let children = self.children.get_or_insert_with(|| HashSet::new());
+        children.insert(rectype.to_string());
     }
 }
+
 #[derive(Clone, Debug)]
 pub struct RecordHierarchy {
     pub root: String,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -89,24 +89,21 @@ impl DatasetLayout {
     pub fn all_variables(&self) -> Vec<LayoutVar> {
         self.record_types()
             .iter()
-            .flat_map(|rt| self.for_rectype(rt).vars.clone())
+            .flat_map(|rt| self.for_rectype(rt).unwrap().vars.clone())
             .collect()
     }
 
     pub fn find_variables(&self, names: &[String]) -> Vec<LayoutVar> {
         self.record_types()
             .iter()
-            .flat_map(|rt| self.for_rectype(rt).filtered(names).vars)
+            .flat_map(|rt| self.for_rectype(rt).unwrap().filtered(names).vars)
             .collect()
     }
 
-    pub fn for_rectype(&self, rt: &str) -> &RecordLayout {
-        match self.layouts.get(rt) {
-            None => {
-                panic!("No records of type {} in layout.", rt);
-            }
-            Some(vars) => vars,
-        }
+    /// Returns the RecordLayout for the given record type, or None if there is
+    /// no layout for that record type.
+    pub fn for_rectype(&self, rt: &str) -> Option<&RecordLayout> {
+        self.layouts.get(rt)
     }
 
     // If you have a Vec of mixed record type LayoutVars, perhaps read in

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -87,9 +87,9 @@ impl DatasetLayout {
     }
 
     pub fn all_variables(&self) -> Vec<LayoutVar> {
-        self.record_types()
-            .iter()
-            .flat_map(|rt| self.for_rectype(rt).unwrap().vars.clone())
+        self.layouts
+            .values()
+            .flat_map(|record_layout| record_layout.vars.clone())
             .collect()
     }
 
@@ -242,7 +242,7 @@ mod tests {
         assert_eq!(
             h_vars + p_vars,
             339,
-            "there should be 339 total variables in the layout (6 lines are ignored due to comments)"
+            "there should be 339 total P and H variables in the layout"
         );
     }
 
@@ -319,5 +319,25 @@ mod tests {
 
         assert_eq!(h_layout.vars[0].name, "YEAR");
         assert_eq!(p_layout.vars[0].name, "AGE");
+    }
+
+    #[test]
+    fn test_dataset_layout_all_variables() {
+        let layout_file = Path::new("test/data_root/layouts/us1850a.layout.txt");
+        let layout = DatasetLayout::try_from_layout_file(layout_file)
+            .expect("should be able to create DatasetLayout from file");
+
+        let all_vars = layout.all_variables();
+        let all_var_names: Vec<_> = all_vars.iter().map(|v| v.name.as_str()).collect();
+        assert_eq!(all_vars.len(), 345, "there should be 339 total variables");
+        assert!(all_var_names.contains(&"AGE"), "should have P variable AGE");
+        assert!(
+            all_var_names.contains(&"METRO"),
+            "should have H variable METRO"
+        );
+        assert!(
+            all_var_names.contains(&"CORE_VERS_RELEASE_NUMBER"),
+            "should have # variable CORE_VERS_RELEASE_NUMBER"
+        );
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -201,9 +201,9 @@ impl DatasetLayout {
         DatasetLayout::try_from_layout_reader(reader)
     }
 
-    // Return a new DatasetLayout containing only the requested variables or an error message.
+    // Return a new DatasetLayout containing only the requested variables or an error.
     // Doing it this way so that we can retain the full layout for reuse.
-    pub fn select_only(&self, selections: Vec<String>) -> Result<DatasetLayout, String> {
+    pub fn select_only(&self, selections: Vec<String>) -> Result<DatasetLayout, MdError> {
         let mut filtered_layouts: HashMap<String, RecordLayout> = HashMap::new();
         let upcased_selections = selections
             .iter()

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -175,15 +175,10 @@ impl DatasetLayout {
             .map(|s| s.to_uppercase())
             .collect::<Vec<String>>();
 
-        for rectype in self.layouts.keys() {
-            filtered_layouts.insert(
-                rectype.clone(),
-                self.layouts
-                    .get(rectype)
-                    .unwrap()
-                    .filtered(&upcased_selections),
-            );
+        for (rectype, layout) in self.layouts.iter() {
+            filtered_layouts.insert(rectype.clone(), layout.filtered(&upcased_selections));
         }
+
         Ok(DatasetLayout {
             layouts: filtered_layouts,
         })

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -149,7 +149,7 @@ impl DatasetLayout {
         // faster to process, defaulting vars to alphabetical order ensures
         // a known schema order that is easy to match with other files or
         // data sources with different natural orderings.
-        all_vars.sort_by(|a, b| b.name.cmp(&a.name));
+        all_vars.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(DatasetLayout::from_layout_vars(all_vars))
     }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -233,6 +233,28 @@ mod tests {
     }
 
     #[test]
+    fn test_dataset_layout_from_layout_file() {
+        let layout_file = Path::new("test/data_root/layouts/us1850a.layout.txt");
+        let layout = DatasetLayout::from_layout_file(layout_file);
+
+        let h_vars = layout.layouts["H"].vars.len();
+        let p_vars = layout.layouts["P"].vars.len();
+        assert_eq!(
+            h_vars + p_vars,
+            339,
+            "there should be 339 total variables in the layout (6 lines are ignored due to comments)"
+        );
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_dataset_layout_from_layout_file_no_such_file_error() {
+        // This is not a real layout file
+        let layout_file = Path::new("test/data_root/layouts/us0000a.layout.txt");
+        let layout = DatasetLayout::from_layout_file(layout_file);
+    }
+
+    #[test]
     fn test_dataset_layout_try_from_layout_reader_variables_sorted_by_name() {
         let layout_data = b"RECTYPE H 1 1 string\n\
         CITY H 60 4 integer\n\

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -146,8 +146,7 @@ impl DatasetLayout {
 
         let mut all_vars = reader
             .records()
-            .filter(|r| r.is_ok())
-            .map(|r| r.unwrap())
+            .filter_map(|r| r.ok())
             .filter(|r| r.len() > 1)
             .map(|record| LayoutVar {
                 name: record[0].to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod conventions;
 pub mod defaults;
+pub mod fixed_width;
 pub mod input_schema_tabulation;
 pub mod ipums_data_model;
 pub mod ipums_metadata_model;

--- a/src/mderror.rs
+++ b/src/mderror.rs
@@ -42,3 +42,35 @@ impl From<duckdb::Error> for MdError {
         MdError::DuckDBError(err)
     }
 }
+
+/// A small convenience macro, based on the format! macro in the standard library.
+///
+/// Instead of directly constructing an `MdError::ParsingError` on a formatted
+/// string, you can use `parse_error!` to get the same result with a little less
+/// typing. The arguments are those you would pass to the format! macro.
+///
+/// `let err = parsing_error!("something wrong with variable {}", variable)`;
+macro_rules! parsing_error {
+    ($($arg:tt)*) => {
+        $crate::mderror::MdError::ParsingError(format!($($arg)*))
+    }
+}
+pub(crate) use parsing_error;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_parse_error_macro() {
+        let variable = "AGE";
+        let dataset = "us2015a";
+        let err = parsing_error!(
+            "something wrong with variable {} in dataset {dataset}",
+            variable
+        );
+
+        assert_eq!(
+            err.to_string(),
+            "parsing error: something wrong with variable AGE in dataset us2015a"
+        );
+    }
+}

--- a/src/mderror.rs
+++ b/src/mderror.rs
@@ -49,7 +49,7 @@ impl From<duckdb::Error> for MdError {
 /// string, you can use `parse_error!` to get the same result with a little less
 /// typing. The arguments are those you would pass to the format! macro.
 ///
-/// `let err = parsing_error!("something wrong with variable {}", variable)`;
+/// `let err = parsing_error!("something wrong with variable {}", variable);`
 macro_rules! parsing_error {
     ($($arg:tt)*) => {
         $crate::mderror::MdError::ParsingError(format!($($arg)*))

--- a/src/mderror.rs
+++ b/src/mderror.rs
@@ -7,6 +7,7 @@ pub enum MdError {
     NotInMetadata(String),
     // The metadata itself doesn't make sense
     InvalidMetadata(String),
+    InvalidSQLSyntax(String),
     // There was an error while parsing the input JSON
     ParsingError(String),
     DuckDBError(duckdb::Error),
@@ -22,6 +23,7 @@ impl fmt::Display for MdError {
             IoError(err) => write!(f, "I/O error: {err}"),
             NotInMetadata(msg) => write!(f, "metadata error: {msg}"),
             InvalidMetadata(msg) => write!(f, "invalid metadata: {msg}"),
+            InvalidSQLSyntax(msg) => write!(f, "SQL syntax error: {msg}"),
             ParsingError(msg) => write!(f, "parsing error: {msg}"),
             DuckDBError(err) => write!(f, "DuckDB error: {err}"),
             Msg(msg) => write!(f, "{msg}"),

--- a/src/mderror.rs
+++ b/src/mderror.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+
 #[derive(Debug)]
 pub enum MdError {
     IoError(std::io::Error),
@@ -8,6 +9,7 @@ pub enum MdError {
     InvalidMetadata(String),
     // There was an error while parsing the input JSON
     ParsingError(String),
+    DuckDBError(duckdb::Error),
     Msg(String),
     // more needed
 }
@@ -21,6 +23,7 @@ impl fmt::Display for MdError {
             NotInMetadata(msg) => write!(f, "metadata error: {msg}"),
             InvalidMetadata(msg) => write!(f, "invalid metadata: {msg}"),
             ParsingError(msg) => write!(f, "parsing error: {msg}"),
+            DuckDBError(err) => write!(f, "DuckDB error: {err}"),
             Msg(msg) => write!(f, "{msg}"),
         }
     }
@@ -31,5 +34,11 @@ impl std::error::Error for MdError {}
 impl From<std::io::Error> for MdError {
     fn from(err: std::io::Error) -> Self {
         MdError::IoError(err)
+    }
+}
+
+impl From<duckdb::Error> for MdError {
+    fn from(err: duckdb::Error) -> Self {
+        MdError::DuckDBError(err)
     }
 }

--- a/src/mderror.rs
+++ b/src/mderror.rs
@@ -2,7 +2,11 @@ use std::fmt;
 #[derive(Debug)]
 pub enum MdError {
     IoError(std::io::Error),
+    // We've requested something in the metadata that is not there
     NotInMetadata(String),
+    // The metadata itself doesn't make sense
+    InvalidMetadata(String),
+    // There was an error while parsing the input JSON
     ParsingError(String),
     Msg(String),
     // more needed
@@ -15,6 +19,7 @@ impl fmt::Display for MdError {
         match self {
             IoError(err) => write!(f, "I/O error: {err}"),
             NotInMetadata(msg) => write!(f, "metadata error: {msg}"),
+            InvalidMetadata(msg) => write!(f, "invalid metadata: {msg}"),
             ParsingError(msg) => write!(f, "parsing error: {msg}"),
             Msg(msg) => write!(f, "{msg}"),
         }

--- a/src/mderror.rs
+++ b/src/mderror.rs
@@ -2,6 +2,7 @@ use std::fmt;
 #[derive(Debug)]
 pub enum MdError {
     IoError(std::io::Error),
+    NotInMetadata(String),
     ParsingError(String),
     Msg(String),
     // more needed
@@ -9,10 +10,13 @@ pub enum MdError {
 
 impl fmt::Display for MdError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use MdError::*;
+
         match self {
-            MdError::IoError(err) => write!(f, "I/O error: {err}"),
-            MdError::ParsingError(msg) => write!(f, "parsing error: {msg}"),
-            MdError::Msg(msg) => write!(f, "{msg}"),
+            IoError(err) => write!(f, "I/O error: {err}"),
+            NotInMetadata(msg) => write!(f, "metadata error: {msg}"),
+            ParsingError(msg) => write!(f, "parsing error: {msg}"),
+            Msg(msg) => write!(f, "{msg}"),
         }
     }
 }

--- a/src/query_gen.rs
+++ b/src/query_gen.rs
@@ -227,7 +227,7 @@ impl TabBuilder {
         if let Some(ref record_type) = ctx.settings.record_types.get(rt) {
             Ok(record_type.unique_id.clone())
         } else {
-            Err(MdError::Msg(format!(
+            Err(MdError::NotInMetadata(format!(
                 "No record type '{}' in current context.",
                 rt
             )))

--- a/src/query_gen.rs
+++ b/src/query_gen.rs
@@ -257,7 +257,7 @@ impl DataSource {
         let paths_by_rectypes = ctx.paths_from_dataset_name(dataset, &input_format);
         let mut data_sources = HashMap::new();
         for rt in ctx.settings.record_types.keys() {
-            let table_alias = ctx.settings.default_table_name(dataset, rt);
+            let table_alias = ctx.settings.default_table_name(dataset, rt)?;
             let p = paths_by_rectypes.get(rt).cloned();
             let ds = DataSource::new(table_alias, p)?;
             data_sources.insert(rt.to_string(), ds);

--- a/src/query_gen.rs
+++ b/src/query_gen.rs
@@ -254,7 +254,7 @@ impl DataSource {
         dataset: &str,
         input_format: &InputType,
     ) -> Result<HashMap<String, DataSource>, MdError> {
-        let paths_by_rectypes = ctx.paths_from_dataset_name(dataset, &input_format);
+        let paths_by_rectypes = ctx.paths_from_dataset_name(dataset, &input_format)?;
         let mut data_sources = HashMap::new();
         for rt in ctx.settings.record_types.keys() {
             let table_alias = ctx.settings.default_table_name(dataset, rt)?;

--- a/src/query_gen.rs
+++ b/src/query_gen.rs
@@ -11,7 +11,7 @@
 //! SQL.
 use crate::conventions::Context;
 use crate::ipums_metadata_model::{self, IpumsDataType};
-use crate::mderror::MdError;
+use crate::mderror::{metadata_error, MdError};
 use crate::request::DataRequest;
 use crate::request::InputType;
 use crate::request::RequestSample;
@@ -235,10 +235,7 @@ impl TabBuilder {
         if let Some(ref record_type) = ctx.settings.record_types.get(rt) {
             Ok(record_type.unique_id.clone())
         } else {
-            Err(MdError::NotInMetadata(format!(
-                "No record type '{}' in current context.",
-                rt
-            )))
+            Err(metadata_error!("No record type '{rt}' in current context.",))
         }
     }
 }

--- a/src/query_gen.rs
+++ b/src/query_gen.rs
@@ -311,7 +311,7 @@ impl DataSource {
                 Self::Parquet { name, .. } => name.to_owned(),
                 Self::Csv { name, .. } => name.to_owned(),
                 Self::NativeTable { name } => {
-                    panic!("No native table type for '{}' in DataFusion.", &name)
+                    todo!("No native table type for '{}' in DataFusion yet.", &name)
                 }
             },
         }

--- a/src/request.rs
+++ b/src/request.rs
@@ -28,7 +28,7 @@ fn context_from_names_helper(
     optional_data_root: Option<String>,
 ) -> Result<(conventions::Context, Vec<IpumsVariable>, Vec<IpumsDataset>), MdError> {
     let mut ctx =
-        conventions::Context::from_ipums_collection_name(product, None, optional_data_root);
+        conventions::Context::from_ipums_collection_name(product, None, optional_data_root)?;
     ctx.load_metadata_for_datasets(requested_datasets)?;
 
     // Get variables from selections
@@ -394,7 +394,7 @@ impl AbacusRequest {
             &request.product,
             None,
             request.data_root.clone(),
-        );
+        )?;
 
         let requested_dataset_names: Vec<_> = request
             .request_samples
@@ -674,7 +674,8 @@ mod test {
     pub fn test_deserialize_into_simple_request() {
         let data_root = String::from("test/data_root");
         let mut ctx =
-            conventions::Context::from_ipums_collection_name("usa", None, Some(data_root));
+            conventions::Context::from_ipums_collection_name("usa", None, Some(data_root))
+                .expect("should be able to load context for USA");
 
         // Load the mentioned datasets and all their associated variables into metadata
         ctx.load_metadata_for_datasets(&["us2016c", "us2014d"])
@@ -753,7 +754,8 @@ mod test {
     #[test]
     fn test_validated_unit_of_analysis_unknown_rectype_error() {
         let context =
-            Context::from_ipums_collection_name("usa", None, Some("test/data_root".to_string()));
+            Context::from_ipums_collection_name("usa", None, Some("test/data_root".to_string()))
+                .expect("should be able to load context for USA");
         let uoa = "Z";
         assert!(
             !context.settings.record_types.contains_key(uoa),

--- a/src/request.rs
+++ b/src/request.rs
@@ -611,7 +611,9 @@ impl DataRequest for SimpleRequest {
             }
             checked_vars
         } else {
-            panic!("Metadata for context not yet set up.");
+            return Err(MdError::Msg(
+                "Metadata for context not yet set up.".to_string(),
+            ));
         };
 
         let datasets = if let Some(ref md) = ctx.settings.metadata {
@@ -627,7 +629,9 @@ impl DataRequest for SimpleRequest {
             }
             checked_samples
         } else {
-            panic!("Metadata for context not yet set up.");
+            return Err(MdError::Msg(
+                "Metadata for context not yet set up.".to_string(),
+            ));
         };
 
         let output_format = OutputFormat::CSV;
@@ -755,17 +759,11 @@ mod test {
             !context.settings.record_types.contains_key(uoa),
             "Z should not be a default record type for USA"
         );
-        let result = validated_unit_of_analysis(&context, Some(uoa.to_string()));
-        match result {
-            Ok(record_type) => {
-                panic!("expected an error, got back an Ok with RecordType {record_type:?}")
-            }
-            Err(err) => {
-                assert!(err
-                    .to_string()
-                    .contains("Record type 'Z' not available for use as unit of analysis"));
-            }
-        }
+        let err = validated_unit_of_analysis(&context, Some(uoa.to_string()))
+            .expect_err("expected an error because Z is not a valid record type");
+        assert!(err
+            .to_string()
+            .contains("Record type 'Z' not available for use as unit of analysis"));
     }
 
     #[test]

--- a/src/request.rs
+++ b/src/request.rs
@@ -84,7 +84,7 @@ impl RequestVariable {
         let general_divisor: usize = if let Some((_, w)) = var.formatting {
             if w == var.general_width {
                 1
-            } else if w < var.general_width {
+            } else if var.general_width < w {
                 let exponent: u32 = (w - var.general_width).try_into().unwrap();
                 let base: i32 = 10;
                 base.pow(exponent).try_into().unwrap()

--- a/src/request.rs
+++ b/src/request.rs
@@ -14,7 +14,7 @@ use crate::{
     input_schema_tabulation,
     input_schema_tabulation::{CategoryBin, GeneralDetailedSelection},
     ipums_metadata_model::{IpumsDataType, IpumsDataset, IpumsVariable},
-    mderror::MdError,
+    mderror::{parsing_error, MdError},
     query_gen::Condition,
 };
 
@@ -582,7 +582,11 @@ impl DataRequest for SimpleRequest {
             }
         };
 
-        let product = parsed["product"].as_str().expect("No 'product' in request");
+        let product = match parsed["product"].as_str() {
+            Some(product) => product,
+            None => return Err(parsing_error!("no 'product' in request")),
+        };
+
         let details = parsed["details"]
             .as_object()
             .expect("No 'details' in request.");

--- a/src/request.rs
+++ b/src/request.rs
@@ -738,4 +738,48 @@ mod test {
             }
         }
     }
+
+    #[test]
+    fn test_request_variable_from_ipums_variable_invalid_widths_error() {
+        let variable = IpumsVariable {
+            id: 0,
+            name: "RELATE".to_string(),
+            data_type: None,
+            label: None,
+            record_type: "P".to_string(),
+            categories: None,
+            formatting: Some((100, 4)),
+            // This is invalid because it's greater than the width in the formatting
+            // field. This will cause the error later.
+            general_width: 5,
+            description: None,
+            category_bins: None,
+        };
+
+        let result = RequestVariable::from_ipums_variable(&variable, true);
+        assert!(result.is_err(), "expected an error but got {result:?}");
+    }
+
+    #[test]
+    fn test_request_variable_from_ipums_variable_valid_general_width() {
+        let variable = IpumsVariable {
+            id: 0,
+            name: "RELATE".to_string(),
+            data_type: None,
+            label: None,
+            record_type: "P".to_string(),
+            categories: None,
+            formatting: Some((100, 4)),
+            general_width: 2,
+            description: None,
+            category_bins: None,
+        };
+
+        let rqv = RequestVariable::from_ipums_variable(&variable, true)
+            .expect("should convert into a RequestVariable");
+        assert_eq!(
+            rqv.general_divisor, 100,
+            "expected a general divisor of 10^(4-2) = 10^2 = 100"
+        );
+    }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -29,7 +29,7 @@ fn context_from_names_helper(
 ) -> Result<(conventions::Context, Vec<IpumsVariable>, Vec<IpumsDataset>), MdError> {
     let mut ctx =
         conventions::Context::from_ipums_collection_name(product, None, optional_data_root);
-    ctx.load_metadata_for_datasets(requested_datasets);
+    ctx.load_metadata_for_datasets(requested_datasets)?;
 
     // Get variables from selections
     let variables = if let Some(ref md) = ctx.settings.metadata {
@@ -403,7 +403,7 @@ impl AbacusRequest {
             .collect();
 
         // Use the names of the requested samples to load partial metadata
-        ctx.load_metadata_for_datasets(requested_dataset_names.as_slice());
+        ctx.load_metadata_for_datasets(requested_dataset_names.as_slice())?;
 
         // With metadata loaded, we can fully instantiate the RequestVariables and RequestSamples
         let uoa = if let Some(u) = ctx.settings.record_types.clone().get(&request.uoa) {
@@ -673,7 +673,8 @@ mod test {
             conventions::Context::from_ipums_collection_name("usa", None, Some(data_root));
 
         // Load the mentioned datasets and all their associated variables into metadata
-        ctx.load_metadata_for_datasets(&["us2016c", "us2014d"]);
+        ctx.load_metadata_for_datasets(&["us2016c", "us2014d"])
+            .expect("should be able to load metadata for datasets");
         if let Some(ref md) = ctx.settings.metadata {
             println!("loaded {} variables.", md.variables_index.len());
             println!("{:?}", md.variables_by_name.get("YEAR"));

--- a/src/request.rs
+++ b/src/request.rs
@@ -524,13 +524,15 @@ impl DataRequest for SimpleRequest {
     }
 
     fn get_request_variables(&self) -> Vec<RequestVariable> {
+        // Note the .expect() below: If we got here from the from_names() then
+        // if the metadata is broken (general detailed probably incorrect), we
+        // simply can't proceed.
         self.variables
             .iter()
-            .map(|v| 
-                // If we got here from the from_names() then if the metadata iis broken (general detailed probably incorrect,) 
-                // we simply can't proceed. 
+            .map(|v| {
                 RequestVariable::from_ipums_variable(v, self.use_general_variables)
-                .expect("Broken metadata."))
+                    .expect("Broken metadata.")
+            })
             .collect()
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -244,10 +244,18 @@ fn validated_unit_of_analysis(
     let unit_rectype = match ctx.settings.record_types.get(&uoa) {
         Some(urt) => urt.clone(),
         None => {
-            let rectype_names = ctx.settings.record_types.keys().cloned();
-            let msg = format!("Record type '{}' not available for use as unit of analysis; the record type is not present in the current context with record types '{:?}'",
-            &uoa,
-            rectype_names);
+            let mut rectype_names = ctx
+                .settings
+                .record_types
+                .keys()
+                .map(|k| k.as_str())
+                .collect::<Vec<_>>();
+            rectype_names.sort();
+            let rectype_names = rectype_names.join(", ");
+            let msg = format!(
+                "Record type '{uoa}' not available for use as unit of analysis; \
+                 the record type is not present in the current context with record types {rectype_names}"
+            );
             return Err(MdError::Msg(msg));
         }
     };

--- a/src/request.rs
+++ b/src/request.rs
@@ -38,7 +38,7 @@ fn context_from_names_helper(
             if let Some(id) = md.variables_by_name.get(&*rv.to_ascii_uppercase()) {
                 loaded_vars.push(md.variables_index[*id].clone());
             } else {
-                return Err(MdError::Msg(format!(
+                return Err(MdError::NotInMetadata(format!(
                     "Variable {} not in any loaded metadata.",
                     rv
                 )));
@@ -55,7 +55,7 @@ fn context_from_names_helper(
             if let Some(id) = md.datasets_by_name.get(*rd) {
                 loaded_datasets.push(md.datasets_index[*id].clone());
             } else {
-                return Err(MdError::Msg(format!(
+                return Err(MdError::NotInMetadata(format!(
                     "No dataset named {} found in metadata or layouts!",
                     rd
                 )));
@@ -256,7 +256,7 @@ fn validated_unit_of_analysis(
                 "Record type '{uoa}' not available for use as unit of analysis; \
                  the record type is not present in the current context with record types {rectype_names}"
             );
-            return Err(MdError::Msg(msg));
+            return Err(MdError::NotInMetadata(msg));
         }
     };
     Ok(unit_rectype)
@@ -404,7 +404,9 @@ impl AbacusRequest {
         let uoa = if let Some(u) = ctx.settings.record_types.clone().get(&request.uoa) {
             u.clone()
         } else {
-            return Err(MdError::Msg("No record type for uoa.".to_string()));
+            return Err(MdError::NotInMetadata(
+                "No record type for uoa.".to_string(),
+            ));
         };
 
         let Some(ref md) = &ctx.settings.metadata else {
@@ -417,7 +419,7 @@ impl AbacusRequest {
         for p in request.request_samples {
             let name = p.name;
             let Some(ipums_ds) = md.cloned_dataset_from_name(&name) else {
-                return Err(MdError::Msg(format!(
+                return Err(MdError::NotInMetadata(format!(
                     "No metadata for dataset named {}",
                     &name
                 )));
@@ -434,7 +436,7 @@ impl AbacusRequest {
             let variable_mnemonic = v.variable_mnemonic;
 
             let Some(ipums_var) = md.cloned_variable_from_name(&variable_mnemonic) else {
-                return Err(MdError::Msg(format!(
+                return Err(MdError::NotInMetadata(format!(
                     "No variable named '{}' in loaded metadata.",
                     variable_mnemonic
                 )));

--- a/src/request.rs
+++ b/src/request.rs
@@ -89,7 +89,7 @@ impl RequestVariable {
                 let base: i32 = 10;
                 base.pow(exponent).try_into().unwrap()
             } else {
-                return Err(MdError::Msg(format!(
+                return Err(MdError::InvalidMetadata(format!(
                     "Bad metadata, general width can't be larger than detailed width on {}",
                     &var.name
                 )));

--- a/src/request.rs
+++ b/src/request.rs
@@ -334,10 +334,10 @@ impl DataRequest for AbacusRequest {
             optional_product_root,
             optional_data_root.clone(),
         )?;
-        let request_variables: Result<Vec<RequestVariable>, MdError> = variables
+        let request_variables = variables
             .iter()
             .map(|v| RequestVariable::from_ipums_variable(v, false))
-            .collect::<Result<Vec<RequestVariable>, MdError>>();
+            .collect::<Result<Vec<RequestVariable>, MdError>>()?;
 
         let request_samples = datasets
             .iter()
@@ -350,7 +350,7 @@ impl DataRequest for AbacusRequest {
             Self {
                 product: product.to_string(),
                 request_samples,
-                request_variables: request_variables.unwrap(),
+                request_variables,
                 unit_rectype,
                 output_format: OutputFormat::CSV,
                 subpopulation: Vec::new(),
@@ -699,6 +699,24 @@ mod test {
         assert_eq!(4, rq.variables.len());
         assert_eq!(rq.product, "usa");
         assert_eq!(1, rq.datasets.len());
+    }
+
+    #[test]
+    fn test_abacus_request_from_names() {
+        let data_root = String::from("test/data_root");
+        let (_ctx, abacus_request) = AbacusRequest::from_names(
+            "usa",
+            &["us2015b"],
+            &["AGE", "MARST", "GQ", "YEAR"],
+            Some("P".to_string()),
+            None,
+            Some(data_root),
+        )
+        .expect("should be able to construct an AbacusRequest from the given names");
+
+        assert_eq!(abacus_request.request_variables.len(), 4);
+        assert_eq!(abacus_request.product, "usa");
+        assert_eq!(abacus_request.request_samples.len(), 1);
     }
 
     #[test]

--- a/src/request.rs
+++ b/src/request.rs
@@ -85,13 +85,17 @@ impl RequestVariable {
             if w == var.general_width {
                 1
             } else if var.general_width < w {
+                // We could avoid this unwrap() by using u32s instead of usizes
+                // during parsing and metadata loading. But as it is, this is
+                // technically a fallible conversion. It's not likely to fail
+                // with normal metadata; we'd need to overflow a u32.
                 let exponent: u32 = (w - var.general_width).try_into().unwrap();
                 let base: usize = 10;
                 base.pow(exponent)
             } else {
                 return Err(MdError::InvalidMetadata(format!(
-                    "Bad metadata, general width can't be larger than detailed width on {}",
-                    &var.name
+                    "variable {} has general width {}, which is larger than its detailed width {}",
+                    var.general_width, w, &var.name
                 )));
             }
         } else {

--- a/src/request.rs
+++ b/src/request.rs
@@ -288,8 +288,7 @@ impl DataRequest for AbacusRequest {
         let conditions = self
             .subpopulation
             .iter()
-            .filter(|rv| rv.case_selection.is_some())
-            .map(|rv_c| rv_c.clone().case_selection.unwrap())
+            .filter_map(|rv| rv.case_selection.clone())
             .collect::<Vec<Condition>>();
         if conditions.len() > 0 {
             Some(conditions)

--- a/src/request.rs
+++ b/src/request.rs
@@ -86,8 +86,8 @@ impl RequestVariable {
                 1
             } else if var.general_width < w {
                 let exponent: u32 = (w - var.general_width).try_into().unwrap();
-                let base: i32 = 10;
-                base.pow(exponent).try_into().unwrap()
+                let base: usize = 10;
+                base.pow(exponent)
             } else {
                 return Err(MdError::InvalidMetadata(format!(
                     "Bad metadata, general width can't be larger than detailed width on {}",
@@ -780,6 +780,52 @@ mod test {
         assert_eq!(
             rqv.general_divisor, 100,
             "expected a general divisor of 10^(4-2) = 10^2 = 100"
+        );
+    }
+
+    #[test]
+    fn test_request_variable_from_ipums_variable_equal_widths() {
+        let variable = IpumsVariable {
+            id: 0,
+            name: "AGE".to_string(),
+            data_type: None,
+            label: None,
+            record_type: "P".to_string(),
+            categories: None,
+            formatting: Some((5, 2)),
+            general_width: 2,
+            description: None,
+            category_bins: None,
+        };
+
+        let rqv = RequestVariable::from_ipums_variable(&variable, true)
+            .expect("should convert into a RequestVariable");
+        assert_eq!(
+            rqv.general_divisor, 1,
+            "expected a general divisor of 1 because the general and detailed widths are the same"
+        );
+    }
+
+    #[test]
+    fn test_request_variable_from_ipums_variable_no_formatting() {
+        let variable = IpumsVariable {
+            id: 0,
+            name: "AGE".to_string(),
+            data_type: None,
+            label: None,
+            record_type: "P".to_string(),
+            categories: None,
+            formatting: None,
+            general_width: 2,
+            description: None,
+            category_bins: None,
+        };
+
+        let rqv = RequestVariable::from_ipums_variable(&variable, true)
+            .expect("should convert into a RequestVariable");
+        assert_eq!(
+            rqv.general_divisor, 1,
+            "expected a general divisor of 1 because there was no detailed width provided"
         );
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -248,7 +248,7 @@ fn validated_unit_of_analysis(
             let msg = format!("Record type '{}' not available for use as unit of analysis; the record type is not present in the current context with record types '{:?}'",
             &uoa,
             rectype_names);
-            panic!("{}", msg);
+            return Err(MdError::Msg(msg));
         }
     };
     Ok(unit_rectype)
@@ -701,5 +701,29 @@ mod test {
             _ => (),
         }
         assert!(abacus_request.is_ok());
+    }
+
+    /// It's an error if the given unit of analysis is not present as a record
+    /// type in the context.
+    #[test]
+    fn test_validated_unit_of_analysis_unknown_rectype_error() {
+        let context =
+            Context::from_ipums_collection_name("usa", None, Some("test/data_root".to_string()));
+        let uoa = "Z";
+        assert!(
+            !context.settings.record_types.contains_key(uoa),
+            "Z should not be a default record type for USA"
+        );
+        let result = validated_unit_of_analysis(&context, Some(uoa.to_string()));
+        match result {
+            Ok(record_type) => {
+                panic!("expected an error, got back an Ok with RecordType {record_type:?}")
+            }
+            Err(err) => {
+                assert!(err
+                    .to_string()
+                    .contains("Record type 'Z' not available for use as unit of analysis"));
+            }
+        }
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -362,7 +362,7 @@ impl DataRequest for AbacusRequest {
     }
 
     fn serialize_to_ipums_json(&self) -> String {
-        panic!("Not implemented.")
+        todo!("Serialization is not yet implemented.")
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -234,7 +234,10 @@ pub fn perform_request(rq: impl DataRequest) -> Result<(), String> {
     todo!("Implement");
 }
 
-fn validated_unit_of_analysis(ctx: &Context, unit_of_analysis: Option<String>) -> RecordType {
+fn validated_unit_of_analysis(
+    ctx: &Context,
+    unit_of_analysis: Option<String>,
+) -> Result<RecordType, MdError> {
     let uoa = unit_of_analysis.unwrap_or(ctx.settings.default_unit_of_analysis.value.clone());
 
     // Check that uoa is present for the current context
@@ -248,7 +251,7 @@ fn validated_unit_of_analysis(ctx: &Context, unit_of_analysis: Option<String>) -
             panic!("{}", msg);
         }
     };
-    unit_rectype
+    Ok(unit_rectype)
 }
 
 /// The Abacus Request type contains variables to tabulate, variables used for conditions and datasets.
@@ -334,7 +337,7 @@ impl DataRequest for AbacusRequest {
             .map(|d| RequestSample::from_ipums_dataset(d))
             .collect();
 
-        let unit_rectype = validated_unit_of_analysis(&ctx, unit_of_analysis);
+        let unit_rectype = validated_unit_of_analysis(&ctx, unit_of_analysis)?;
         Ok((
             ctx,
             Self {
@@ -504,7 +507,7 @@ impl DataRequest for SimpleRequest {
             optional_product_root,
             optional_data_root,
         )?;
-        let unit_rectype = validated_unit_of_analysis(&ctx, unit_of_analysis);
+        let unit_rectype = validated_unit_of_analysis(&ctx, unit_of_analysis)?;
         Ok((
             ctx,
             Self {
@@ -608,7 +611,8 @@ impl DataRequest for SimpleRequest {
         let output_format = OutputFormat::CSV;
 
         let unit_of_analysis = None;
-        let unit_rectype = validated_unit_of_analysis(&ctx, unit_of_analysis);
+        let unit_rectype =
+            validated_unit_of_analysis(&ctx, unit_of_analysis).expect("invalid unit of analysis");
 
         Ok(Self {
             product: product.to_string(),

--- a/src/tabulate.rs
+++ b/src/tabulate.rs
@@ -134,17 +134,17 @@ impl Table {
             TableFormat::Html | TableFormat::Csv => {
                 todo!("Output format {:?} not implemented yet.", format)
             }
-            TableFormat::Json => self.format_as_json(),
+            TableFormat::Json => self.format_as_json().unwrap(),
             TableFormat::TextTable => self.format_as_text(),
         }
     }
 
-    pub fn format_as_json(&self) -> String {
+    pub fn format_as_json(&self) -> Result<String, MdError> {
         match serde_json::to_string_pretty(&self) {
-            Ok(j) => j,
-            Err(e) => {
-                panic!("Cannot serialize result into json: {}", e);
-            }
+            Ok(j) => Ok(j),
+            Err(e) => Err(MdError::Msg(format!(
+                "Cannot serialize result into json: {e}"
+            ))),
         }
     }
 

--- a/src/tabulate.rs
+++ b/src/tabulate.rs
@@ -13,7 +13,7 @@ use crate::query_gen::DataPlatform;
 use crate::request::DataRequest;
 use crate::request::InputType;
 use crate::request::RequestVariable;
-use duckdb::{Connection, Result};
+use duckdb::Connection;
 
 use serde::Serialize;
 
@@ -26,13 +26,13 @@ pub enum TableFormat {
 }
 
 impl TableFormat {
-    pub fn from_str(name: &str) -> Result<Self, String> {
+    pub fn from_str(name: &str) -> Result<Self, MdError> {
         let tf = match name.to_ascii_lowercase().as_str() {
             "csv" => Self::Csv,
             "json" => Self::Json,
             "text" => Self::TextTable,
             "html" => Self::Html,
-            _ => return Err("unknown format name.".to_string()),
+            _ => return Err(MdError::Msg("unknown format name.".to_string())),
         };
         Ok(tf)
     }

--- a/src/tabulate.rs
+++ b/src/tabulate.rs
@@ -132,7 +132,7 @@ impl Table {
     pub fn output(&self, format: TableFormat) -> String {
         match format {
             TableFormat::Html | TableFormat::Csv => {
-                panic!("Output format not implemented yet.")
+                todo!("Output format {:?} not implemented yet.", format)
             }
             TableFormat::Json => self.format_as_json(),
             TableFormat::TextTable => self.format_as_text(),

--- a/src/tabulate.rs
+++ b/src/tabulate.rs
@@ -196,7 +196,7 @@ impl Table {
                         widths.push(name_width);
                     }
                 } else {
-                    panic!("Can't determine column width of data.");
+                    return Err(MdError::Msg("Can't determine column width of data.".to_string()));
                 }
             }
             */

--- a/src/tabulate.rs
+++ b/src/tabulate.rs
@@ -7,7 +7,7 @@
 
 use crate::conventions::Context;
 use crate::ipums_metadata_model::IpumsDataType;
-use crate::mderror::MdError;
+use crate::mderror::{metadata_error, MdError};
 use crate::query_gen::tab_queries;
 use crate::query_gen::DataPlatform;
 use crate::request::DataRequest;
@@ -79,8 +79,7 @@ impl Serialize for OutputColumn {
                 let data_type = match v.variable.data_type {
                     Some(ref data_type) => data_type.to_string(),
                     None => {
-                        let err =
-                            MdError::Msg(format!("missing data type for variable {}", v.name));
+                        let err = metadata_error!("missing data type for variable {}", v.name);
                         return Err(S::Error::custom(err));
                     }
                 };
@@ -110,9 +109,7 @@ impl OutputColumn {
                     if let Some((_, wid)) = v.variable.formatting {
                         Ok(wid)
                     } else {
-                        Err(MdError::InvalidMetadata(
-                            "width from metadata variable required".to_string(),
-                        ))
+                        Err(metadata_error!("width from metadata variable required"))
                     }
                 } else {
                     Ok(v.variable.general_width)

--- a/src/tabulate.rs
+++ b/src/tabulate.rs
@@ -99,18 +99,20 @@ impl OutputColumn {
         }
     }
 
-    pub fn width(&self) -> usize {
+    pub fn width(&self) -> Result<usize, MdError> {
         match self {
-            Self::Constructed { ref width, .. } => *width,
+            Self::Constructed { ref width, .. } => Ok(*width),
             Self::RequestVar(ref v) => {
                 if !v.is_general {
                     if let Some((_, wid)) = v.variable.formatting {
-                        wid
+                        Ok(wid)
                     } else {
-                        panic!("Width from metadata Variable required.");
+                        Err(MdError::InvalidMetadata(
+                            "width from metadata variable required".to_string(),
+                        ))
                     }
                 } else {
-                    v.variable.general_width
+                    Ok(v.variable.general_width)
                 }
             }
         }
@@ -180,7 +182,7 @@ impl Table {
         let mut widths = Vec::new();
         for (_column, var) in self.heading.iter().enumerate() {
             let name_width = var.name().len();
-            let width = var.width();
+            let width = var.width().unwrap();
             if name_width < width {
                 widths.push(width);
             } else {

--- a/src/tabulate.rs
+++ b/src/tabulate.rs
@@ -264,7 +264,7 @@ pub fn tabulate(ctx: &Context, rq: impl DataRequest) -> Result<Vec<Table>, MdErr
         });
         output.heading.extend(requested_output_columns.clone());
 
-        while let Some(row) = rows.next().expect("Error reading row.") {
+        while let Some(row) = rows.next()? {
             let mut this_row = Vec::new();
             // Must do this here on row rather than getting column_names() from
             // stmt.column_names() because of a bug in the DuckDB API -- it

--- a/src/tabulate.rs
+++ b/src/tabulate.rs
@@ -230,20 +230,10 @@ pub fn tabulate(ctx: &Context, rq: impl DataRequest) -> Result<Vec<Table>, MdErr
 
     let mut tables: Vec<Table> = Vec::new();
     let sql_queries = tab_queries(ctx, rq, &InputType::Parquet, &DataPlatform::Duckdb)?;
-    let conn = match Connection::open_in_memory() {
-        Ok(c) => c,
-        Err(e) => return Err(MdError::Msg(format!("{}", e))),
-    };
+    let conn = Connection::open_in_memory()?;
     for q in sql_queries {
-        let mut stmt = match conn.prepare(&q) {
-            Ok(results) => results,
-            Err(e) => return Err(MdError::Msg(format!("{}", e))),
-        };
-
-        let mut rows = match stmt.query([]) {
-            Ok(r) => r,
-            Err(e) => return Err(MdError::Msg(format!("{}", e))),
-        };
+        let mut stmt = conn.prepare(&q)?;
+        let mut rows = stmt.query([])?;
 
         let mut output = Table {
             heading: Vec::new(),


### PR DESCRIPTION
In this PR I've done my best to remove panics and crashes from the library. I've converted these to `MdError`s or refactored them away where possible. I've also added some unit tests for these error conditions where it wasn't too difficult, so those are a big chunk of the added lines.

Some notes:
- I added a couple of simple macros to the mderror.rs module to save some typing for two common error variants and to learn a little bit about macros. The two macros are `parsing_error!` and `metadata_error!`, and they work in pretty much the same way. Instead of writing

```
MdError::ParsingError(format!("something went wrong while parsing variable {}", variable))
```

you can now get the same results with

```
parsing_error!("something went wrong while parsing variable {}", variable)
```

- There are a couple of panics left in the program. One in `request::RequestVariable::from_ipums_variable` is due to shrinking from a `usize` to a `u32`, which is technically a fallible operation but is unlikely to fail for us. Another in `request::SimpleRequest::get_request_variables()` is tricky because it's inside of a trait-defined function. So I didn't want to alter the function signature to return an error. We can probably get around this one by converting from `IpumsVariable`s to `RequestVariable`s during deserialization, and returning the errors there.
- There are a couple of expects in the binaries which could probably be converted to better error handling in the future.
- In a few cases where a function was named `from_*` but I modified it so that it can return an error, I've renamed the function to `try_from_*`.
- I've created some new `MdError` variants. We now have variants for I/O errors, metadata errors, SQL syntax errors, parsing errors, internal DuckDB errors, and a generic error variant. These are a rough draft. We can keep adding to and changing them as we go.