### PR TITLE
Fix 1940 sl variables

### DIFF
--- a/src/conventions.rs
+++ b/src/conventions.rs
@@ -56,9 +56,21 @@ impl MicroDataCollection {
         Some(weight.name.clone())
     }
 
+    pub fn sample_line_weight_for_rectype(&self, rt: &str) -> Option<String> {
+        let rectype = self.record_types.get(rt)?;
+        let weight = &rectype.sample_weight.clone()?;
+        Some(weight.name.clone())
+    }
+
     pub fn weight_divisor(&self, rt: &str) -> Option<usize> {
         let rectype = self.record_types.get(rt)?;
         let weight = &rectype.weight.clone()?;
+        Some(weight.divisor)
+    }
+
+    pub fn sample_line_weight_divisor(&self, rt: &str) -> Option<usize> {
+        let rectype = self.record_types.get(rt)?;
+        let weight = &rectype.sample_weight.clone()?;
         Some(weight.divisor)
     }
 

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -22,7 +22,7 @@ fn household(_product: &str) -> RecordType {
 
 fn person(product: &str) -> RecordType {
     let slwt = match product.to_lowercase().as_ref() {
-        "usa" =>  Some(usa_sample_line_weight()),
+        "usa" => Some(usa_sample_line_weight()),
         _ => None,
     };
 
@@ -38,9 +38,15 @@ fn person(product: &str) -> RecordType {
 
 fn default_record_types(product: &str) -> HashMap<String, RecordType> {
     match product.to_lowercase().as_ref() {
-        "usa" | "ipumsi" | "cps" => HashMap::from([("H".to_string(), household(product)), ("P".to_string(), person(product))]),
+        "usa" | "ipumsi" | "cps" => HashMap::from([
+            ("H".to_string(), household(product)),
+            ("P".to_string(), person(product)),
+        ]),
         // TODO add some other default hierarchies or load from a config file
-        _ =>HashMap::from([("H".to_string(), household(product)), ("P".to_string(), person(product))]),
+        _ => HashMap::from([
+            ("H".to_string(), household(product)),
+            ("P".to_string(), person(product)),
+        ]),
     }
 }
 
@@ -52,7 +58,7 @@ fn default_person_weight() -> RecordWeight {
     RecordWeight::new("PERWT", 100)
 }
 
-fn usa_sample_line_weight() ->RecordWeight {
+fn usa_sample_line_weight() -> RecordWeight {
     RecordWeight::new("SLWT", 100)
 }
 

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -9,28 +9,39 @@ use crate::ipums_data_model::*;
 use crate::mderror::MdError;
 use std::collections::HashMap;
 
-fn household() -> RecordType {
+fn household(_product: &str) -> RecordType {
     RecordType {
         name: "Household".to_string(),
         value: "H".to_string(),
         unique_id: "SERIAL".to_string(),
         foreign_keys: Vec::new(),
         weight: Some(default_household_weight()),
+        sample_weight: None,
     }
 }
 
-fn person() -> RecordType {
+fn person(product: &str) -> RecordType {
+    let slwt = match product.to_lowercase().as_ref() {
+        "usa" =>  Some(usa_sample_line_weight()),
+        _ => None,
+    };
+
     RecordType {
         name: "Person".to_string(),
         value: "P".to_string(),
         unique_id: "PSERIAL".to_string(),
         foreign_keys: vec![("H".to_string(), "SERIALP".to_string())],
         weight: Some(default_person_weight()),
+        sample_weight: slwt,
     }
 }
 
-fn default_record_types() -> HashMap<String, RecordType> {
-    HashMap::from([("H".to_string(), household()), ("P".to_string(), person())])
+fn default_record_types(product: &str) -> HashMap<String, RecordType> {
+    match product.to_lowercase().as_ref() {
+        "usa" | "ipumsi" | "cps" => HashMap::from([("H".to_string(), household(product)), ("P".to_string(), person(product))]),
+        // TODO add some other default hierarchies or load from a config file
+        _ =>HashMap::from([("H".to_string(), household(product)), ("P".to_string(), person(product))]),
+    }
 }
 
 fn default_household_weight() -> RecordWeight {
@@ -39,6 +50,10 @@ fn default_household_weight() -> RecordWeight {
 
 fn default_person_weight() -> RecordWeight {
     RecordWeight::new("PERWT", 100)
+}
+
+fn usa_sample_line_weight() ->RecordWeight {
+    RecordWeight::new("SLWT", 100)
 }
 
 fn default_hierarchy() -> RecordHierarchy {
@@ -52,8 +67,8 @@ fn default_settings_named(name: &str) -> MicroDataCollection {
     MicroDataCollection {
         name: name.to_string(),
         record_hierarchy: default_hierarchy(),
-        record_types: default_record_types(),
-        default_unit_of_analysis: person(),
+        record_types: default_record_types(name),
+        default_unit_of_analysis: person(name),
         metadata: None,
     }
 }

--- a/src/ipums_data_model.rs
+++ b/src/ipums_data_model.rs
@@ -17,6 +17,12 @@ pub struct RecordType {
     pub unique_id: String,                   // Like SERIAL for household, PSERIAL for Person etc
     pub foreign_keys: Vec<(String, String)>, // RecordType name,  key name: like 'Household', 'serialp'
     pub weight: Option<RecordWeight>,
+
+    // Some datasets will have a "sample line weight" where only certain records / people
+    // have non N/A values for some variables. This type of weight will be 0 for many
+    // records. When using this weight instead of the main weight you will get a correctly
+    // weighted subsample.
+    pub sample_weight: Option<RecordWeight>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/query_gen.rs
+++ b/src/query_gen.rs
@@ -301,7 +301,7 @@ impl TabBuilder {
         let from_clause = &self.build_from_clause(ctx, &self.dataset, &uoa, &rectypes)?;
 
         let vars_in_order = self.help_final_var_aliases(&request_variables);
-        
+
         let group_by_clause = vars_in_order.join(", ");
         let order_by_clause = vars_in_order.join(", ");
 


### PR DESCRIPTION
Add support for USA sample line weights in 1940 and 1950. This is unpleasantly specific and I went ahead and made some helper functions in the query_gen module to look for USA and us1940a, us1950a, us1940b, us1950b. If you're not tabulating those datasets, no behavior changes

The metadata models change slightly to allow a `RecordType` type to have a sample line weight in addition to the standard weight variable.

Needs more testing but to do so I need to prepare a 0.01% 1940a sample and add to the test fixtures. It will require some calculations on what's a "correct" tabulation from that.