### PR TITLE
Add more integration tests

### DIFF
--- a/tests/requests/ftotinc_category_bins_complex_subpop.json
+++ b/tests/requests/ftotinc_category_bins_complex_subpop.json
@@ -1,0 +1,185 @@
+{
+  "product": "usa",
+  "data_root": "tests/data_root",
+  "uoa": "P",
+  "output_format": "json",
+  "subpopulation": [
+    {
+      "variable_mnemonic": "FARM",
+      "mnemonic": "FARM",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": true,
+      "request_case_selections": [
+        {
+          "low_code": "1",
+          "high_code": "1"
+        }
+      ],
+      "include_dq_flags": false,
+      "extract_start": 8,
+      "extract_width": 1
+    },
+    {
+      "variable_mnemonic": "EDUC",
+      "mnemonic": "EDUC",
+      "general_detailed_selection": "G",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": true,
+      "request_case_selections": [
+        {
+          "low_code": "060",
+          "high_code": "065"
+        },
+        {
+          "low_code": "070",
+          "high_code": "071"
+        },
+        {
+          "low_code": "080",
+          "high_code": "083"
+        },
+        {
+          "low_code": "090",
+          "high_code": "090"
+        },
+        {
+          "low_code": "100",
+          "high_code": "101"
+        }
+      ],
+      "include_dq_flags": false,
+      "extract_start": 9,
+      "extract_width": 2
+    }
+  ],
+  "category_bins": {
+    "FTOTINC": [
+      {
+        "code": 0,
+        "value_label": "N/A",
+        "low": 9999999,
+        "high": 9999999
+      },
+      {
+        "code": 1,
+        "value_label": "Less than $10,000",
+        "low": null,
+        "high": 9999
+      },
+      {
+        "code": 2,
+        "value_label": "$10,000 to $14,999",
+        "low": 10000,
+        "high": 14999
+      },
+      {
+        "code": 3,
+        "value_label": "$15,000 to $19,999",
+        "low": 15000,
+        "high": 19999
+      },
+      {
+        "code": 4,
+        "value_label": "$20,000 to $24,999",
+        "low": 20000,
+        "high": 24999
+      },
+      {
+        "code": 5,
+        "value_label": "$25,000 to $29,999",
+        "low": 25000,
+        "high": 29999
+      },
+      {
+        "code": 6,
+        "value_label": "$30,000 to $34,999",
+        "low": 30000,
+        "high": 34999
+      },
+      {
+        "code": 7,
+        "value_label": "$35,000 to $39,999",
+        "low": 35000,
+        "high": 39999
+      },
+      {
+        "code": 8,
+        "value_label": "$40,000 to $44,999",
+        "low": 40000,
+        "high": 44999
+      },
+      {
+        "code": 9,
+        "value_label": "$45,000 to $49,999",
+        "low": 45000,
+        "high": 49999
+      },
+      {
+        "code": 10,
+        "value_label": "$50,000 to $59,999",
+        "low": 50000,
+        "high": 59999
+      },
+      {
+        "code": 11,
+        "value_label": "$60,000 to $74,999",
+        "low": 60000,
+        "high": 74999
+      },
+      {
+        "code": 12,
+        "value_label": "$75,000 to $99,999",
+        "low": 75000,
+        "high": 99999
+      },
+      {
+        "code": 13,
+        "value_label": "$100,000 to $124,999",
+        "low": 100000,
+        "high": 124999
+      },
+      {
+        "code": 14,
+        "value_label": "$125,000 to $149,999",
+        "low": 125000,
+        "high": 149999
+      },
+      {
+        "code": 15,
+        "value_label": "$150,000 to $199,999",
+        "low": 150000,
+        "high": 199999
+      },
+      {
+        "code": 16,
+        "value_label": "$200,000 or more",
+        "low": 200000,
+        "high": 9999998
+      }
+    ]
+  },
+  "request_samples": [
+    {
+      "name": "us2015b",
+      "custom_sampling_ratio": null,
+      "first_household_sampled": null
+    }
+  ],
+  "request_variables": [
+    {
+      "variable_mnemonic": "FTOTINC",
+      "mnemonic": "FTOTINC",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": false,
+      "request_case_selections": [],
+      "include_dq_flags": false,
+      "extract_start": 1,
+      "extract_width": 7
+    }
+  ]
+}

--- a/tests/requests/ftotinc_category_bins_no_subpops.json
+++ b/tests/requests/ftotinc_category_bins_no_subpops.json
@@ -1,0 +1,134 @@
+{
+  "product": "usa",
+  "data_root": "tests/data_root",
+  "uoa": "P",
+  "output_format": "json",
+  "subpopulation": [],
+  "category_bins": {
+    "FTOTINC": [
+      {
+        "code": 0,
+        "value_label": "N/A",
+        "low": 9999999,
+        "high": 9999999
+      },
+      {
+        "code": 1,
+        "value_label": "Less than $10,000",
+        "low": null,
+        "high": 9999
+      },
+      {
+        "code": 2,
+        "value_label": "$10,000 to $14,999",
+        "low": 10000,
+        "high": 14999
+      },
+      {
+        "code": 3,
+        "value_label": "$15,000 to $19,999",
+        "low": 15000,
+        "high": 19999
+      },
+      {
+        "code": 4,
+        "value_label": "$20,000 to $24,999",
+        "low": 20000,
+        "high": 24999
+      },
+      {
+        "code": 5,
+        "value_label": "$25,000 to $29,999",
+        "low": 25000,
+        "high": 29999
+      },
+      {
+        "code": 6,
+        "value_label": "$30,000 to $34,999",
+        "low": 30000,
+        "high": 34999
+      },
+      {
+        "code": 7,
+        "value_label": "$35,000 to $39,999",
+        "low": 35000,
+        "high": 39999
+      },
+      {
+        "code": 8,
+        "value_label": "$40,000 to $44,999",
+        "low": 40000,
+        "high": 44999
+      },
+      {
+        "code": 9,
+        "value_label": "$45,000 to $49,999",
+        "low": 45000,
+        "high": 49999
+      },
+      {
+        "code": 10,
+        "value_label": "$50,000 to $59,999",
+        "low": 50000,
+        "high": 59999
+      },
+      {
+        "code": 11,
+        "value_label": "$60,000 to $74,999",
+        "low": 60000,
+        "high": 74999
+      },
+      {
+        "code": 12,
+        "value_label": "$75,000 to $99,999",
+        "low": 75000,
+        "high": 99999
+      },
+      {
+        "code": 13,
+        "value_label": "$100,000 to $124,999",
+        "low": 100000,
+        "high": 124999
+      },
+      {
+        "code": 14,
+        "value_label": "$125,000 to $149,999",
+        "low": 125000,
+        "high": 149999
+      },
+      {
+        "code": 15,
+        "value_label": "$150,000 to $199,999",
+        "low": 150000,
+        "high": 199999
+      },
+      {
+        "code": 16,
+        "value_label": "$200,000 or more",
+        "low": 200000,
+        "high": 9999998
+      }
+    ]
+  },
+  "request_samples": [
+    {
+      "name": "us2015b",
+      "custom_sampling_ratio": null,
+      "first_household_sampled": null
+    }
+  ],
+  "request_variables": [
+    {
+      "variable_mnemonic": "FTOTINC",
+      "mnemonic": "FTOTINC",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": false,
+      "request_case_selections": [],
+      "include_dq_flags": false,
+      "extract_start": 1,
+      "extract_width": 7
+    }
+  ]
+}

--- a/tests/requests/ftotinc_category_bins_subpop_H_variable.json
+++ b/tests/requests/ftotinc_category_bins_subpop_H_variable.json
@@ -1,0 +1,152 @@
+{
+  "product": "usa",
+  "data_root": "tests/data_root",
+  "uoa": "P",
+  "output_format": "json",
+  "subpopulation": [
+    {
+      "variable_mnemonic": "FARM",
+      "mnemonic": "FARM",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": true,
+      "request_case_selections": [
+        {
+          "low_code": "2",
+          "high_code": "2"
+        }
+      ],
+      "include_dq_flags": false,
+      "extract_start": 8,
+      "extract_width": 1
+    }
+  ],
+  "category_bins": {
+    "FTOTINC": [
+      {
+        "code": 0,
+        "value_label": "N/A",
+        "low": 9999999,
+        "high": 9999999
+      },
+      {
+        "code": 1,
+        "value_label": "Less than $10,000",
+        "low": null,
+        "high": 9999
+      },
+      {
+        "code": 2,
+        "value_label": "$10,000 to $14,999",
+        "low": 10000,
+        "high": 14999
+      },
+      {
+        "code": 3,
+        "value_label": "$15,000 to $19,999",
+        "low": 15000,
+        "high": 19999
+      },
+      {
+        "code": 4,
+        "value_label": "$20,000 to $24,999",
+        "low": 20000,
+        "high": 24999
+      },
+      {
+        "code": 5,
+        "value_label": "$25,000 to $29,999",
+        "low": 25000,
+        "high": 29999
+      },
+      {
+        "code": 6,
+        "value_label": "$30,000 to $34,999",
+        "low": 30000,
+        "high": 34999
+      },
+      {
+        "code": 7,
+        "value_label": "$35,000 to $39,999",
+        "low": 35000,
+        "high": 39999
+      },
+      {
+        "code": 8,
+        "value_label": "$40,000 to $44,999",
+        "low": 40000,
+        "high": 44999
+      },
+      {
+        "code": 9,
+        "value_label": "$45,000 to $49,999",
+        "low": 45000,
+        "high": 49999
+      },
+      {
+        "code": 10,
+        "value_label": "$50,000 to $59,999",
+        "low": 50000,
+        "high": 59999
+      },
+      {
+        "code": 11,
+        "value_label": "$60,000 to $74,999",
+        "low": 60000,
+        "high": 74999
+      },
+      {
+        "code": 12,
+        "value_label": "$75,000 to $99,999",
+        "low": 75000,
+        "high": 99999
+      },
+      {
+        "code": 13,
+        "value_label": "$100,000 to $124,999",
+        "low": 100000,
+        "high": 124999
+      },
+      {
+        "code": 14,
+        "value_label": "$125,000 to $149,999",
+        "low": 125000,
+        "high": 149999
+      },
+      {
+        "code": 15,
+        "value_label": "$150,000 to $199,999",
+        "low": 150000,
+        "high": 199999
+      },
+      {
+        "code": 16,
+        "value_label": "$200,000 or more",
+        "low": 200000,
+        "high": 9999998
+      }
+    ]
+  },
+  "request_samples": [
+    {
+      "name": "us2015b",
+      "custom_sampling_ratio": null,
+      "first_household_sampled": null
+    }
+  ],
+  "request_variables": [
+    {
+      "variable_mnemonic": "FTOTINC",
+      "mnemonic": "FTOTINC",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": false,
+      "request_case_selections": [],
+      "include_dq_flags": false,
+      "extract_start": 1,
+      "extract_width": 7
+    }
+  ]
+}

--- a/tests/requests/ftotinc_category_bins_subpop_P_variable.json
+++ b/tests/requests/ftotinc_category_bins_subpop_P_variable.json
@@ -1,0 +1,152 @@
+{
+  "product": "usa",
+  "data_root": "tests/data_root",
+  "uoa": "P",
+  "output_format": "json",
+  "subpopulation": [
+    {
+      "variable_mnemonic": "EDUC",
+      "mnemonic": "EDUC",
+      "general_detailed_selection": "G",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": true,
+      "request_case_selections": [
+        {
+          "low_code": "060",
+          "high_code": "065"
+        }
+      ],
+      "include_dq_flags": false,
+      "extract_start": 8,
+      "extract_width": 2
+    }
+  ],
+  "category_bins": {
+    "FTOTINC": [
+      {
+        "code": 0,
+        "value_label": "N/A",
+        "low": 9999999,
+        "high": 9999999
+      },
+      {
+        "code": 1,
+        "value_label": "Less than $10,000",
+        "low": null,
+        "high": 9999
+      },
+      {
+        "code": 2,
+        "value_label": "$10,000 to $14,999",
+        "low": 10000,
+        "high": 14999
+      },
+      {
+        "code": 3,
+        "value_label": "$15,000 to $19,999",
+        "low": 15000,
+        "high": 19999
+      },
+      {
+        "code": 4,
+        "value_label": "$20,000 to $24,999",
+        "low": 20000,
+        "high": 24999
+      },
+      {
+        "code": 5,
+        "value_label": "$25,000 to $29,999",
+        "low": 25000,
+        "high": 29999
+      },
+      {
+        "code": 6,
+        "value_label": "$30,000 to $34,999",
+        "low": 30000,
+        "high": 34999
+      },
+      {
+        "code": 7,
+        "value_label": "$35,000 to $39,999",
+        "low": 35000,
+        "high": 39999
+      },
+      {
+        "code": 8,
+        "value_label": "$40,000 to $44,999",
+        "low": 40000,
+        "high": 44999
+      },
+      {
+        "code": 9,
+        "value_label": "$45,000 to $49,999",
+        "low": 45000,
+        "high": 49999
+      },
+      {
+        "code": 10,
+        "value_label": "$50,000 to $59,999",
+        "low": 50000,
+        "high": 59999
+      },
+      {
+        "code": 11,
+        "value_label": "$60,000 to $74,999",
+        "low": 60000,
+        "high": 74999
+      },
+      {
+        "code": 12,
+        "value_label": "$75,000 to $99,999",
+        "low": 75000,
+        "high": 99999
+      },
+      {
+        "code": 13,
+        "value_label": "$100,000 to $124,999",
+        "low": 100000,
+        "high": 124999
+      },
+      {
+        "code": 14,
+        "value_label": "$125,000 to $149,999",
+        "low": 125000,
+        "high": 149999
+      },
+      {
+        "code": 15,
+        "value_label": "$150,000 to $199,999",
+        "low": 150000,
+        "high": 199999
+      },
+      {
+        "code": 16,
+        "value_label": "$200,000 or more",
+        "low": 200000,
+        "high": 9999998
+      }
+    ]
+  },
+  "request_samples": [
+    {
+      "name": "us2015b",
+      "custom_sampling_ratio": null,
+      "first_household_sampled": null
+    }
+  ],
+  "request_variables": [
+    {
+      "variable_mnemonic": "FTOTINC",
+      "mnemonic": "FTOTINC",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": false,
+      "request_case_selections": [],
+      "include_dq_flags": false,
+      "extract_start": 1,
+      "extract_width": 7
+    }
+  ]
+}

--- a/tests/requests/multiple_request_samples.json
+++ b/tests/requests/multiple_request_samples.json
@@ -1,0 +1,34 @@
+{
+  "product": "usa",
+  "data_root": "tests/data_root",
+  "uoa": "P",
+  "output_format": "json",
+  "subpopulation": [],
+  "category_bins": {},
+  "request_samples": [
+    {
+      "name": "us2015b",
+      "custom_sampling_ratio": null,
+      "first_household_sampled": null
+    },
+    {
+      "name": "us2016b",
+      "custom_sampling_ratio": null,
+      "first_household_sampled": null
+    }
+  ],
+  "request_variables": [
+    {
+      "variable_mnemonic": "CINETHH",
+      "mnemonic": "CINETHH",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": false,
+      "request_case_selections": [],
+      "include_dq_flags": false,
+      "extract_start": 1,
+      "extract_width": 1
+    }
+  ]
+}

--- a/tests/requests/multiple_variables_mixed_category_bins_no_subpops.json
+++ b/tests/requests/multiple_variables_mixed_category_bins_no_subpops.json
@@ -1,0 +1,68 @@
+{
+  "product": "usa",
+  "data_root": "tests/data_root",
+  "uoa": "P",
+  "output_format": "json",
+  "subpopulation": [],
+  "category_bins": {
+    "UHRSWORK": [
+      {
+        "code": 0,
+        "value_label": "N/A",
+        "low": 0,
+        "high": 0
+      },
+      {
+        "code": 1,
+        "value_label": "1 to 14 hours worked per week",
+        "low": 1,
+        "high": 14
+      },
+      {
+        "code": 2,
+        "value_label": "15 to 34 hours worked per week",
+        "low": 15,
+        "high": 34
+      },
+      {
+        "code": 3,
+        "value_label": "35 or more hours worked per week",
+        "low": 35,
+        "high": 99
+      }
+    ]
+  },
+  "request_samples": [
+    {
+      "name": "us2015b",
+      "custom_sampling_ratio": null,
+      "first_household_sampled": null
+    }
+  ],
+  "request_variables": [
+    {
+      "variable_mnemonic": "GQ",
+      "mnemonic": "GQ",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": false,
+      "request_case_selections": [],
+      "include_dq_flags": false,
+      "extract_start": 1,
+      "extract_width": 1
+    },
+    {
+      "variable_mnemonic": "UHRSWORK",
+      "mnemonic": "UHRSWORK",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": false,
+      "request_case_selections": [],
+      "include_dq_flags": false,
+      "extract_start": 2,
+      "extract_width": 2
+    }
+  ]
+}

--- a/tests/requests/multiple_variables_mixed_category_bins_subpop_P_variable.json
+++ b/tests/requests/multiple_variables_mixed_category_bins_subpop_P_variable.json
@@ -1,0 +1,86 @@
+{
+  "product": "usa",
+  "data_root": "tests/data_root",
+  "uoa": "P",
+  "output_format": "json",
+  "subpopulation": [
+    {
+      "variable_mnemonic": "LOOKING",
+      "mnemonic": "LOOKING",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": true,
+      "request_case_selections": [
+        {
+          "low_code": "2",
+          "high_code": "2"
+        }
+      ],
+      "include_dq_flags": false,
+      "extract_start": 4,
+      "extract_width": 1
+    }
+  ],
+  "category_bins": {
+    "UHRSWORK": [
+      {
+        "code": 0,
+        "value_label": "N/A",
+        "low": 0,
+        "high": 0
+      },
+      {
+        "code": 1,
+        "value_label": "1 to 14 hours worked per week",
+        "low": 1,
+        "high": 14
+      },
+      {
+        "code": 2,
+        "value_label": "15 to 34 hours worked per week",
+        "low": 15,
+        "high": 34
+      },
+      {
+        "code": 3,
+        "value_label": "35 or more hours worked per week",
+        "low": 35,
+        "high": 99
+      }
+    ]
+  },
+  "request_samples": [
+    {
+      "name": "us2015b",
+      "custom_sampling_ratio": null,
+      "first_household_sampled": null
+    }
+  ],
+  "request_variables": [
+    {
+      "variable_mnemonic": "GQ",
+      "mnemonic": "GQ",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": false,
+      "request_case_selections": [],
+      "include_dq_flags": false,
+      "extract_start": 1,
+      "extract_width": 1
+    },
+    {
+      "variable_mnemonic": "UHRSWORK",
+      "mnemonic": "UHRSWORK",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": false,
+      "request_case_selections": [],
+      "include_dq_flags": false,
+      "extract_start": 2,
+      "extract_width": 2
+    }
+  ]
+}

--- a/tests/requests/no_category_bins_complex_subpop.json
+++ b/tests/requests/no_category_bins_complex_subpop.json
@@ -1,0 +1,68 @@
+{
+  "product": "usa",
+  "data_root": "tests/data_root",
+  "uoa": "P",
+  "output_format": "json",
+  "subpopulation": [
+    {
+      "variable_mnemonic": "SEX",
+      "mnemonic": "SEX",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": true,
+      "request_case_selections": [
+        {
+          "low_code": "2",
+          "high_code": "2"
+        }
+      ],
+      "include_dq_flags": false,
+      "extract_start": 2,
+      "extract_width": 1
+    },
+    {
+      "variable_mnemonic": "METRO",
+      "mnemonic": "METRO",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": true,
+      "request_case_selections": [
+        {
+          "low_code": "3",
+          "high_code": "3"
+        },
+        {
+          "low_code": "1",
+          "high_code": "1"
+        }
+      ],
+      "include_dq_flags": false,
+      "extract_start": 3,
+      "extract_width": 1
+    }
+  ],
+  "category_bins": {},
+  "request_samples": [
+    {
+      "name": "us2015b",
+      "custom_sampling_ratio": null,
+      "first_household_sampled": null
+    }
+  ],
+  "request_variables": [
+    {
+      "variable_mnemonic": "MARST",
+      "mnemonic": "MARST",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": false,
+      "request_case_selections": [],
+      "include_dq_flags": false,
+      "extract_start": 1,
+      "extract_width": 1
+    }
+  ]
+}

--- a/tests/test_tabulate.rs
+++ b/tests/test_tabulate.rs
@@ -255,6 +255,48 @@ fn test_category_bins_subpop_h_variable() {
     key.check(&table);
 }
 
+/// This test tabulates the FTOTINC variable with category bins and a fairly
+/// complex subpopulation. The subpopulation is "people who don't live on a farm, and
+/// whose educational attainment is either Grade 12 or 1-4 years of college".
+/// This subpopulation involves the H variable FARM and multiple conditions on
+/// the P variable EDUC.
+#[test]
+fn test_category_bins_complex_subpop() {
+    let input_json = include_str!("requests/ftotinc_category_bins_complex_subpop.json");
+    let (ctx, rq) =
+        AbacusRequest::try_from_json(input_json).expect("should be able to parse input JSON");
+    let tab = tabulate(&ctx, rq).expect("should be able to tabulate without errors");
+
+    let tables = tab.into_inner();
+    assert_eq!(tables.len(), 1, "expected exactly 1 output table");
+    let table = tables[0].clone();
+
+    let key = KeyTable {
+        column_names: ["ct", "weighted_ct", "FTOTINC"],
+        rows: [
+            [438, 18273, 0],
+            [3464, 397424, 1],
+            [1721, 191838, 2],
+            [1674, 191139, 3],
+            [1447, 161257, 4],
+            [1195, 139253, 5],
+            [1164, 127114, 6],
+            [1077, 121966, 7],
+            [885, 96782, 8],
+            [749, 84157, 9],
+            [1118, 125347, 10],
+            [1042, 125185, 11],
+            [838, 96101, 12],
+            [377, 39820, 13],
+            [142, 17098, 14],
+            [84, 8735, 15],
+            [265, 29556, 16],
+        ],
+    };
+
+    key.check(&table);
+}
+
 /// A helpful struct for simplifying comparisons of a tabulation result to a key
 /// table. Uses const generics W (width) and H (height) to keep track of the width
 /// and height of the table. Has its own tests in this file.

--- a/tests/test_tabulate.rs
+++ b/tests/test_tabulate.rs
@@ -187,6 +187,44 @@ fn test_category_bins_no_subpops() {
     key.check(&table);
 }
 
+/// This request tabulates FTOTINC with the subpopulation 60 <= EDUC <= 65.
+#[test]
+fn test_category_bins_subpop_p_variable() {
+    let input_json = include_str!("requests/ftotinc_category_bins_subpop_P_variable.json");
+    let (ctx, rq) =
+        AbacusRequest::try_from_json(input_json).expect("should be able to parse input JSON");
+    let tab = tabulate(&ctx, rq).expect("should be able to tabulate without errors");
+
+    let tables = tab.into_inner();
+    assert_eq!(tables.len(), 1, "expected exactly one input table");
+    let table = tables[0].clone();
+
+    let key = KeyTable {
+        column_names: ["ct", "weighted_ct", "FTOTINC"],
+        rows: [
+            [283, 11554, 0],
+            [2128, 238373, 1],
+            [990, 107469, 2],
+            [918, 100487, 3],
+            [678, 69712, 4],
+            [532, 58371, 5],
+            [473, 53488, 6],
+            [394, 42347, 7],
+            [300, 30003, 8],
+            [254, 27070, 9],
+            [373, 37396, 10],
+            [273, 31653, 11],
+            [216, 22396, 12],
+            [89, 9190, 13],
+            [20, 2171, 14],
+            [13, 1008, 15],
+            [50, 4954, 16],
+        ],
+    };
+
+    key.check(&table);
+}
+
 /// A helpful struct for simplifying comparisons of a tabulation result to a key
 /// table. Uses const generics W (width) and H (height) to keep track of the width
 /// and height of the table. Has its own tests in this file.

--- a/tests/test_tabulate.rs
+++ b/tests/test_tabulate.rs
@@ -297,9 +297,46 @@ fn test_category_bins_complex_subpop() {
     key.check(&table);
 }
 
+/// Each request sample gets its own output table.
+#[test]
+fn test_multiple_request_samples() {
+    let input_json = include_str!("requests/multiple_request_samples.json");
+    let (ctx, rq) =
+        AbacusRequest::try_from_json(input_json).expect("should be able to parse input JSON");
+    let tab = tabulate(&ctx, rq).expect("should run tabulation without errors");
+
+    let tables = tab.into_inner();
+    assert_eq!(tables.len(), 2, "expected exactly 2 output tables");
+    let table_us2015b = tables[0].clone();
+    let table_us2016b = tables[1].clone();
+
+    let key_us2015b = KeyTable {
+        column_names: ["ct", "weighted_ct", "CINETHH"],
+        rows: [
+            [897, 39460, 0],
+            [17698, 2042631, 1],
+            [1262, 162305, 2],
+            [10910, 1229786, 3],
+        ],
+    };
+
+    let key_us2016b = KeyTable {
+        column_names: ["ct", "weighted_ct", "CINETHH"],
+        rows: [
+            [801, 39617, 0],
+            [19634, 2271203, 1],
+            [598, 70448, 2],
+            [9191, 1030039, 3],
+        ],
+    };
+
+    key_us2015b.check(&table_us2015b);
+    key_us2016b.check(&table_us2016b);
+}
+
 /// A helpful struct for simplifying comparisons of a tabulation result to a key
 /// table. Uses const generics W (width) and H (height) to keep track of the width
-/// and height of the table. Has its own tests in this file.
+/// and height of the table.
 ///
 /// Rows are type usize for convenience. If necessary we can switch this to &'a str
 /// to preserve formatting of integers. Or we could create a new type parameter

--- a/tests/test_tabulate.rs
+++ b/tests/test_tabulate.rs
@@ -334,6 +334,45 @@ fn test_multiple_request_samples() {
     key_us2016b.check(&table_us2016b);
 }
 
+/// This test tabulates the two variables GQ and UHRSWORK. GQ does not have
+/// category bins applied, but UHRSWORK does. There is no subpopulation requested.
+#[test]
+fn test_multiple_variables_mixed_category_bins_no_subpops() {
+    let input_json =
+        include_str!("requests/multiple_variables_mixed_category_bins_no_subpops.json");
+    let (ctx, rq) =
+        AbacusRequest::try_from_json(input_json).expect("should be able to parse input JSON");
+    let tab = tabulate(&ctx, rq).expect("should tabulate without errors");
+
+    let tables = tab.into_inner();
+    assert_eq!(tables.len(), 1, "expected exactly 1 output table");
+    let table = tables[0].clone();
+
+    let key = KeyTable {
+        column_names: ["ct", "weighted_ct", "GQ", "UHRSWORK"],
+        rows: [
+            [20527, 2328045, 1, 0],
+            [549, 60884, 1, 1],
+            [2318, 279919, 1, 2],
+            [6452, 762702, 1, 3],
+            [19, 2369, 2, 0],
+            [2, 435, 2, 1],
+            [1, 112, 2, 2],
+            [2, 256, 2, 3],
+            [484, 21902, 3, 0],
+            [8, 258, 3, 1],
+            [38, 1257, 3, 2],
+            [57, 1860, 3, 3],
+            [242, 10719, 4, 0],
+            [15, 676, 4, 1],
+            [37, 1850, 4, 2],
+            [16, 938, 4, 3],
+        ],
+    };
+
+    key.check(&table);
+}
+
 /// A helpful struct for simplifying comparisons of a tabulation result to a key
 /// table. Uses const generics W (width) and H (height) to keep track of the width
 /// and height of the table.
@@ -349,6 +388,9 @@ struct KeyTable<'a, const W: usize, const H: usize> {
 
 impl<'a, const W: usize, const H: usize> KeyTable<'a, W, H> {
     pub fn check(&self, table: &Table) {
+        dbg!(self);
+        dbg!(table);
+
         self.check_heading(table);
         self.check_row_dimensions(table);
         self.check_row_entries(table);

--- a/tests/test_tabulate.rs
+++ b/tests/test_tabulate.rs
@@ -225,6 +225,36 @@ fn test_category_bins_subpop_p_variable() {
     key.check(&table);
 }
 
+/// This test tabulates FTOTINC over the subpopulation FARM = 2 (which is households
+/// that are on farms; FARM is an H variable). Since us2015b is a relatively
+/// small sample, there are several category bins of FTOTINC which have a count
+/// of 0. These categories do not appear in the output table.
+#[test]
+fn test_category_bins_subpop_h_variable() {
+    let input_json = include_str!("requests/ftotinc_category_bins_subpop_H_variable.json");
+    let (ctx, rq) =
+        AbacusRequest::try_from_json(input_json).expect("should be able to parse input JSON");
+    let tab = tabulate(&ctx, rq).expect("should tabulate without errors");
+
+    let tables = tab.into_inner();
+    assert_eq!(tables.len(), 1, "expected exactly one output table");
+    let table = tables[0].clone();
+
+    let key = KeyTable {
+        column_names: ["ct", "weighted_ct", "FTOTINC"],
+        rows: [
+            [7, 498, 1],
+            [9, 1187, 4],
+            [6, 507, 7],
+            [2, 259, 8],
+            [6, 389, 10],
+            [4, 925, 12],
+        ],
+    };
+
+    key.check(&table);
+}
+
 /// A helpful struct for simplifying comparisons of a tabulation result to a key
 /// table. Uses const generics W (width) and H (height) to keep track of the width
 /// and height of the table. Has its own tests in this file.

--- a/tests/test_tabulate.rs
+++ b/tests/test_tabulate.rs
@@ -148,6 +148,45 @@ fn test_general_selection_for_general_detailed_variable() {
     key.check(&table);
 }
 
+/// The variable FTOTINC is a P variable, and in this request it has 17 category
+/// bins.
+#[test]
+fn test_category_bins_no_subpops() {
+    let input_json = include_str!("requests/ftotinc_category_bins_no_subpops.json");
+    let (ctx, rq) =
+        AbacusRequest::try_from_json(input_json).expect("should be able to parse input JSON");
+    let tab = tabulate(&ctx, rq).expect("should be able to tabulate without errors");
+
+    let tables = tab.into_inner();
+    assert_eq!(tables.len(), 1, "expected exactly one output table");
+    let table = tables[0].clone();
+
+    let key = KeyTable {
+        column_names: ["ct", "weighted_ct", "FTOTINC"],
+        rows: [
+            [908, 40725, 0],
+            [7532, 880096, 1],
+            [3264, 371129, 2],
+            [2871, 327968, 3],
+            [2355, 271148, 4],
+            [1821, 214895, 5],
+            [1803, 200163, 6],
+            [1565, 179681, 7],
+            [1342, 147771, 8],
+            [1118, 126565, 9],
+            [1682, 190799, 10],
+            [1601, 195258, 11],
+            [1334, 155015, 12],
+            [608, 65219, 13],
+            [243, 29161, 14],
+            [179, 18680, 15],
+            [541, 59909, 16],
+        ],
+    };
+
+    key.check(&table);
+}
+
 /// A helpful struct for simplifying comparisons of a tabulation result to a key
 /// table. Uses const generics W (width) and H (height) to keep track of the width
 /// and height of the table. Has its own tests in this file.

--- a/tests/test_tabulate.rs
+++ b/tests/test_tabulate.rs
@@ -373,6 +373,34 @@ fn test_multiple_variables_mixed_category_bins_no_subpops() {
     key.check(&table);
 }
 
+/// This test tabulates the GQ and UHRSWORK variables over the subpopulation
+/// LOOKING = 2.
+#[test]
+fn test_multiple_variables_mixed_category_bins_subpop_p_variable() {
+    let input_json =
+        include_str!("requests/multiple_variables_mixed_category_bins_subpop_P_variable.json");
+    let (ctx, rq) =
+        AbacusRequest::try_from_json(input_json).expect("should be able to parse input JSON");
+    let tab = tabulate(&ctx, rq).expect("should tabulate without errors");
+
+    let tables = tab.into_inner();
+    assert_eq!(tables.len(), 1, "expected exactly one output table");
+    let table = tables[0].clone();
+
+    let key = KeyTable {
+        column_names: ["ct", "weighted_ct", "GQ", "UHRSWORK"],
+        rows: [
+            [1419, 184886, 1, 0],
+            [62, 6410, 1, 1],
+            [179, 21363, 1, 2],
+            [224, 26152, 1, 3],
+            [1, 85, 3, 0],
+            [34, 1524, 4, 0],
+        ],
+    };
+
+    key.check(&table);
+}
 /// A helpful struct for simplifying comparisons of a tabulation result to a key
 /// table. Uses const generics W (width) and H (height) to keep track of the width
 /// and height of the table.

--- a/tests/test_tabulate.rs
+++ b/tests/test_tabulate.rs
@@ -82,6 +82,35 @@ fn test_no_category_bins_subpop_h_variable() {
     key.check(&table);
 }
 
+/// This request has a complex subpopulation of "METRO (an H variable) is either
+/// 1 or 3, and SEX (a P variable) is 2".
+#[test]
+fn test_no_category_bins_complex_subpop() {
+    let input_json = include_str!("requests/no_category_bins_complex_subpop.json");
+
+    let (ctx, rq) =
+        AbacusRequest::try_from_json(input_json).expect("should be able to parse input JSON");
+    let tab = tabulate(&ctx, rq).expect("tabulation should run without errors");
+
+    let tables = tab.into_inner();
+    assert_eq!(tables.len(), 1, "expected exactly 1 output table");
+    let table = tables[0].clone();
+
+    let key = KeyTable {
+        column_names: ["ct", "weighted_ct", "MARST"],
+        rows: [
+            [2270, 234510, 1],
+            [127, 016015, 2],
+            [186, 23503, 3],
+            [922, 104773, 4],
+            [752, 66727, 5],
+            [2663, 365164, 6],
+        ],
+    };
+
+    key.check(&table);
+}
+
 /// The variable RELATE has a detailed version which has a width of 4 bytes and
 /// a general version with a width of 2 bytes. When a request specifies the general
 /// version for RELATE, the results are aggregated on the general codes, which


### PR DESCRIPTION
This PR adds 8 more integration tests for the `tabulate::tabulate()` function. They test various combinations of features like category bins, subpopulations, and multiple request samples. All of them are passing; all of these features seem to be working correctly.

I have a few more test cases planned, but I wanted to get this merged before starting to work on a different bug I've found.