### PR TITLE
Make request case selection bounds optional

### DIFF
--- a/src/input_schema_tabulation.rs
+++ b/src/input_schema_tabulation.rs
@@ -153,22 +153,38 @@ impl TryFrom<RequestCaseSelectionRaw> for RequestCaseSelection {
     type Error = MdError;
 
     fn try_from(value: RequestCaseSelectionRaw) -> Result<Self, Self::Error> {
-        let Ok(low_code) = value.low_code.expect("low_code is missing").parse() else {
-            return Err(parsing_error!(
-                "request_case_selections: cannot parse low_code as an unsigned integer",
-            ));
-        };
+        let low_code: Option<u64> = value
+            .low_code
+            .map(|s| {
+                s.parse().map_err(|err| {
+                    parsing_error!(
+                    "cannot parse request_case_selections low_code as an unsigned integer: {err}"
+                )
+                })
+            })
+            .transpose()?;
 
-        let Ok(high_code) = value.high_code.expect("high_code is missing").parse() else {
-            return Err(parsing_error!(
-                "request_case_selections: cannot parse high_code as an unsigned integer"
-            ));
-        };
+        let high_code: Option<u64> = value
+            .high_code
+            .map(|s| {
+                s.parse().map_err(|err| {
+                    parsing_error!(
+                "cannot parse request_case_selections high_code as an unsigned integer: {err}"
+                )
+                })
+            })
+            .transpose()?;
+
+        println!("{low_code:?}");
+        println!("{high_code:?}");
 
         if high_code < low_code {
-            Err(MdError::Msg(format!("request_case_selections: a low_code of {low_code} and high_code of {high_code} do not satisfy low_code <= high_code")))
+            Err(MdError::Msg(format!("request_case_selections: a low_code of {low_code:?} and high_code of {high_code:?} do not satisfy low_code <= high_code")))
         } else {
-            Ok(Self::Between(low_code, high_code))
+            Ok(Self::Between(
+                low_code.expect("low_code is missing"),
+                high_code.expect("high_code is missing"),
+            ))
         }
     }
 }

--- a/src/input_schema_tabulation.rs
+++ b/src/input_schema_tabulation.rs
@@ -175,16 +175,14 @@ impl TryFrom<RequestCaseSelectionRaw> for RequestCaseSelection {
             })
             .transpose()?;
 
-        println!("{low_code:?}");
-        println!("{high_code:?}");
-
-        if high_code < low_code {
-            Err(MdError::Msg(format!("request_case_selections: a low_code of {low_code:?} and high_code of {high_code:?} do not satisfy low_code <= high_code")))
-        } else {
-            Ok(Self::Between(
-                low_code.expect("low_code is missing"),
-                high_code.expect("high_code is missing"),
-            ))
+        match (low_code, high_code) {
+            (None, None) => Err(panic!("this will be an error")),
+            (Some(low_code), None) => Ok(Self::GreaterEqual(low_code)),
+            (None, Some(high_code)) => Ok(Self::LessEqual(high_code)),
+            (Some(low_code), Some(high_code)) if low_code <= high_code => {
+                Ok(Self::Between(low_code, high_code))
+            }
+            (Some(low_code), Some(high_code)) => Err(panic!("this will be an error")),
         }
     }
 }

--- a/src/input_schema_tabulation.rs
+++ b/src/input_schema_tabulation.rs
@@ -176,13 +176,15 @@ impl TryFrom<RequestCaseSelectionRaw> for RequestCaseSelection {
             .transpose()?;
 
         match (low_code, high_code) {
-            (None, None) => Err(panic!("this will be an error")),
+            (None, None) => Err(parsing_error!(
+                "at most one of request_case_selections low_code and high_code may be null"
+            )),
             (Some(low_code), None) => Ok(Self::GreaterEqual(low_code)),
             (None, Some(high_code)) => Ok(Self::LessEqual(high_code)),
             (Some(low_code), Some(high_code)) if low_code <= high_code => {
                 Ok(Self::Between(low_code, high_code))
             }
-            (Some(low_code), Some(high_code)) => Err(panic!("this will be an error")),
+            (Some(low_code), Some(high_code)) => Err(parsing_error!("request_case_selections low_code must be <= high_code; got low_code={low_code}, high_code={high_code}")),
         }
     }
 }

--- a/src/query_gen.rs
+++ b/src/query_gen.rs
@@ -12,7 +12,7 @@
 
 use crate::conventions::Context;
 
-use crate::input_schema_tabulation::{self, CategoryBin};
+use crate::input_schema_tabulation::{self, CategoryBin, RequestCaseSelection};
 use crate::ipums_metadata_model::{self, IpumsDataType, IpumsVariable};
 use crate::mderror::{metadata_error, MdError};
 use crate::request::CaseSelectLogic;
@@ -583,15 +583,19 @@ impl Condition {
         };
         let maybe_comparisons = rcs
             .iter()
-            .map(|cs| {
-                todo!()
-                // if cs.low_code < cs.high_code {
-                // Ok(CompareOperation::Between(format!("{}",cs.low_code), format!("{}",cs.high_code)))
-                // } else if cs.low_code == cs.high_code {
-                // Ok(CompareOperation::Equal(format!("{}", cs.low_code)))
-                // } else {
-                // Err(MdError::Msg(format!("Case selection low code must be lower or equal to high code on '{}': {}, {}", &var.name, cs.low_code, cs.high_code)))
-                // }
+            .map(|cs| match cs {
+                RequestCaseSelection::LessEqual(code) => {
+                    Ok(CompareOperation::LessEqual(code.to_string()))
+                }
+                RequestCaseSelection::GreaterEqual(code) => {
+                    Ok(CompareOperation::GreaterEqual(code.to_string()))
+                }
+                RequestCaseSelection::Between(low, high) if low == high => {
+                    Ok(CompareOperation::Equal(low.to_string()))
+                }
+                RequestCaseSelection::Between(low, high) => {
+                    Ok(CompareOperation::Between(low.to_string(), high.to_string()))
+                }
             })
             .collect::<Result<Vec<CompareOperation>, MdError>>();
         let comparisons = maybe_comparisons?;

--- a/src/query_gen.rs
+++ b/src/query_gen.rs
@@ -581,15 +581,17 @@ impl Condition {
         } else {
             IpumsDataType::Integer
         };
-        let maybe_comparisons = rcs.iter()
+        let maybe_comparisons = rcs
+            .iter()
             .map(|cs| {
-                if cs.low_code < cs.high_code {
-                    Ok(CompareOperation::Between(format!("{}",cs.low_code), format!("{}",cs.high_code)))
-                } else if cs.low_code == cs.high_code {
-                    Ok(CompareOperation::Equal(format!("{}", cs.low_code)))
-                } else {
-                    Err(MdError::Msg(format!("Case selection low code must be lower or equal to high code on '{}': {}, {}", &var.name, cs.low_code, cs.high_code)))
-                }
+                todo!()
+                // if cs.low_code < cs.high_code {
+                // Ok(CompareOperation::Between(format!("{}",cs.low_code), format!("{}",cs.high_code)))
+                // } else if cs.low_code == cs.high_code {
+                // Ok(CompareOperation::Equal(format!("{}", cs.low_code)))
+                // } else {
+                // Err(MdError::Msg(format!("Case selection low code must be lower or equal to high code on '{}': {}, {}", &var.name, cs.low_code, cs.high_code)))
+                // }
             })
             .collect::<Result<Vec<CompareOperation>, MdError>>();
         let comparisons = maybe_comparisons?;

--- a/src/query_gen.rs
+++ b/src/query_gen.rs
@@ -12,7 +12,7 @@
 
 use crate::conventions::Context;
 
-use crate::input_schema_tabulation::{self, CategoryBin, RequestCaseSelection};
+use crate::input_schema_tabulation::{CategoryBin, RequestCaseSelection};
 use crate::ipums_metadata_model::{self, IpumsDataType, IpumsVariable};
 use crate::mderror::{metadata_error, MdError};
 use crate::request::CaseSelectLogic;
@@ -574,31 +574,31 @@ impl Condition {
 
     pub fn try_from_request_case_selections(
         var: &IpumsVariable,
-        rcs: &[input_schema_tabulation::RequestCaseSelection],
+        rcs: &[RequestCaseSelection],
     ) -> Result<Option<Self>, MdError> {
         let data_type = if let Some(ref dt) = var.data_type {
             dt.clone()
         } else {
             IpumsDataType::Integer
         };
-        let maybe_comparisons = rcs
+        let comparisons: Vec<CompareOperation> = rcs
             .iter()
             .map(|cs| match cs {
                 RequestCaseSelection::LessEqual(code) => {
-                    Ok(CompareOperation::LessEqual(code.to_string()))
+                    CompareOperation::LessEqual(code.to_string())
                 }
                 RequestCaseSelection::GreaterEqual(code) => {
-                    Ok(CompareOperation::GreaterEqual(code.to_string()))
+                    CompareOperation::GreaterEqual(code.to_string())
                 }
                 RequestCaseSelection::Between(low, high) if low == high => {
-                    Ok(CompareOperation::Equal(low.to_string()))
+                    CompareOperation::Equal(low.to_string())
                 }
                 RequestCaseSelection::Between(low, high) => {
-                    Ok(CompareOperation::Between(low.to_string(), high.to_string()))
+                    CompareOperation::Between(low.to_string(), high.to_string())
                 }
             })
-            .collect::<Result<Vec<CompareOperation>, MdError>>();
-        let comparisons = maybe_comparisons?;
+            .collect();
+
         if comparisons.len() == 0 {
             Ok(None)
         } else {
@@ -653,6 +653,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::input_schema_tabulation;
     use crate::request::context_from_names_helper;
     use crate::request::SimpleRequest;
 

--- a/tests/requests/request_case_selections_no_low_code.json
+++ b/tests/requests/request_case_selections_no_low_code.json
@@ -1,0 +1,152 @@
+{
+  "product": "usa",
+  "data_root": "tests/data_root",
+  "uoa": "P",
+  "output_format": "json",
+  "subpopulation": [
+    {
+      "variable_mnemonic": "FTOTINC",
+      "mnemonic": "FTOTINC",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": true,
+      "request_case_selections": [
+        {
+          "low_code": null,
+          "high_code": "9999"
+        }
+      ],
+      "include_dq_flags": false,
+      "extract_start": 2,
+      "extract_width": 7
+    }
+  ],
+  "category_bins": {
+    "FTOTINC": [
+      {
+        "code": 0,
+        "value_label": "N/A",
+        "low": 9999999,
+        "high": 9999999
+      },
+      {
+        "code": 1,
+        "value_label": "Less than $10,000",
+        "low": null,
+        "high": 9999
+      },
+      {
+        "code": 2,
+        "value_label": "$10,000 to $14,999",
+        "low": 10000,
+        "high": 14999
+      },
+      {
+        "code": 3,
+        "value_label": "$15,000 to $19,999",
+        "low": 15000,
+        "high": 19999
+      },
+      {
+        "code": 4,
+        "value_label": "$20,000 to $24,999",
+        "low": 20000,
+        "high": 24999
+      },
+      {
+        "code": 5,
+        "value_label": "$25,000 to $29,999",
+        "low": 25000,
+        "high": 29999
+      },
+      {
+        "code": 6,
+        "value_label": "$30,000 to $34,999",
+        "low": 30000,
+        "high": 34999
+      },
+      {
+        "code": 7,
+        "value_label": "$35,000 to $39,999",
+        "low": 35000,
+        "high": 39999
+      },
+      {
+        "code": 8,
+        "value_label": "$40,000 to $44,999",
+        "low": 40000,
+        "high": 44999
+      },
+      {
+        "code": 9,
+        "value_label": "$45,000 to $49,999",
+        "low": 45000,
+        "high": 49999
+      },
+      {
+        "code": 10,
+        "value_label": "$50,000 to $59,999",
+        "low": 50000,
+        "high": 59999
+      },
+      {
+        "code": 11,
+        "value_label": "$60,000 to $74,999",
+        "low": 60000,
+        "high": 74999
+      },
+      {
+        "code": 12,
+        "value_label": "$75,000 to $99,999",
+        "low": 75000,
+        "high": 99999
+      },
+      {
+        "code": 13,
+        "value_label": "$100,000 to $124,999",
+        "low": 100000,
+        "high": 124999
+      },
+      {
+        "code": 14,
+        "value_label": "$125,000 to $149,999",
+        "low": 125000,
+        "high": 149999
+      },
+      {
+        "code": 15,
+        "value_label": "$150,000 to $199,999",
+        "low": 150000,
+        "high": 199999
+      },
+      {
+        "code": 16,
+        "value_label": "$200,000 or more",
+        "low": 200000,
+        "high": 9999998
+      }
+    ]
+  },
+  "request_samples": [
+    {
+      "name": "us2015b",
+      "custom_sampling_ratio": null,
+      "first_household_sampled": null
+    }
+  ],
+  "request_variables": [
+    {
+      "variable_mnemonic": "FARM",
+      "mnemonic": "FARM",
+      "general_detailed_selection": "",
+      "standardization_index": null,
+      "attached_variable_pointer": null,
+      "case_selection": false,
+      "request_case_selections": [],
+      "include_dq_flags": false,
+      "extract_start": 1,
+      "extract_width": 1
+    }
+  ]
+}

--- a/tests/test_tabulate.rs
+++ b/tests/test_tabulate.rs
@@ -119,6 +119,26 @@ fn test_general_selection_for_general_detailed_variable() {
     key.check(&table);
 }
 
+/// The low_code attribute can be null for request_case_selections. This indicates
+/// that there is no lower bound, so it's a <= comparison.
+#[test]
+fn test_request_case_selections_no_low_code() {
+    let input_json = include_str!("requests/request_case_selections_no_low_code.json");
+    let (ctx, rq) =
+        AbacusRequest::try_from_json(input_json).expect("should be able to parse input JSON");
+    let tab = tabulate(&ctx, rq).expect("should tabulate without errors");
+    let tables = tab.into_inner();
+    assert_eq!(tables.len(), 1, "expected exactly 1 output table");
+    let table = tables[0].clone();
+
+    let key = KeyTable {
+        column_names: ["ct", "weighted_ct", "FARM"],
+        rows: [[7525, 879598, 1], [7, 498, 2]],
+    };
+
+    key.check(&table);
+}
+
 /// A helpful struct for simplifying comparisons of a tabulation result to a key
 /// table. Uses const generics W (width) and H (height) to keep track of the width
 /// and height of the table. Has its own tests in this file.


### PR DESCRIPTION
You can now set either `low_code` or `high_code` to `null` in request case selections to indicate that there is no bound in that direction. Setting both attributes to `null` is an error because that's basically doing no comparison at all.

I refactored `input_schema_tabulation::RequestCaseSelection` to be an enum instead of a struct to better capture the three possible relationships between the low code and high code. This enum looks suspiciously close to both `CategoryBin` and `CompareOperation`. There might be some opportunities to unify these structs in the future, but it's not yet clear to me how to refactor to do that.

I've added some new unit tests and an integration test which was failing but now passes.

One weird note: we convert from `String` to `u64` in `RequestCaseSelection` for comparison's sake between the `u64`s. But then we convert the `u64`s back into `String`s for `CompareOperation`.